### PR TITLE
removing package-lock from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+package-lock.json


### PR DESCRIPTION
### **What does this PR do?**
this PR removes package-lock from repo
adding package-lock.json in gitignore

## How should this be manually tested?

- `Clone the repo`

- `checkout` to branch `ch-add-tailwind-to-the-project`

- Pull the changes by `git pull`

- Install all packages by running `npm install`

- Start app by `running npm run dev`

- you should find that package-lock is ignored while pushing to remote repo