### PR TITLE
Feature:  add a new dynamic fields for any new  trainee 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "googleapis": "^108.0.0",
     "graphql": "^16.6.0",
     "mongoose": "^6.6.1",
+    "mongoose-dynamic-schemas": "^1.2.6",
     "ts-node-dev": "^2.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,15 @@ import  {usersResolvers}  from "./resolvers/userResolver";
 import { updateUserTypeDefs } from "./schema/updateUserTypeDefs";
 import { recyclebinresolver} from "./resolvers/emptyrecycle";
 import recyclebinempty from "./schema/recyclebin";
+import { typeDefsAdditionalFields } from "./schema/additionalFiledsTypeDefs";
+import additionalAttributesFieldResolver from "./resolvers/additionalAttributeField";
 
 
 
 const PORT = process.env.PORT || 4001;
 
-const resolvers = mergeResolvers([applicationCycleResolver, usersResolvers,traineeAttributeResolver, traineeApplicantResolver, traineeResolvers, filterTraineeResolver,recyclebinresolver])
-const typeDefs= mergeTypeDefs([applicationCycleTypeDefs, typeDefsAttribute, typeDefsTrainee, updateUserTypeDefs, deleteTraineTypeDefs, filterTraineetypeDefs,recyclebinempty ])
+const resolvers = mergeResolvers([applicationCycleResolver, usersResolvers,traineeAttributeResolver, traineeApplicantResolver, traineeResolvers, filterTraineeResolver,recyclebinresolver, additionalAttributesFieldResolver])
+const typeDefs= mergeTypeDefs([applicationCycleTypeDefs, typeDefsAttribute, typeDefsTrainee, updateUserTypeDefs, deleteTraineTypeDefs, filterTraineetypeDefs,recyclebinempty, typeDefsAdditionalFields ])
 
 const server = new ApolloServer({
   typeDefs,

--- a/src/models/additionalAttributes.ts
+++ b/src/models/additionalAttributes.ts
@@ -1,0 +1,18 @@
+import mongoose, { model, Schema } from "mongoose";
+
+const additionalFields = new Schema({
+
+  fieldName: {
+    type: String,
+    required: true,
+  },
+  keyvalue: {
+    type: String,
+    require: true,
+
+  },
+},);
+
+const additionalAttributesField = model("AdditionalFields", additionalFields);
+
+export { additionalAttributesField };

--- a/src/models/traineeAttribute.ts
+++ b/src/models/traineeAttribute.ts
@@ -92,9 +92,14 @@ const traineeAttributeSchema = new Schema({
   trainee_id: {
     type: mongoose.Schema.Types.ObjectId,
     ref: "Trainee",
-    required: true,
+    required: false,
   },
-});
+  additional_fields: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "AdditionalFields",
+    required: false
+  },
+},);
 
 const traineEAttributes = model("Attributes", traineeAttributeSchema);
 

--- a/src/resolvers/DelTranee.ts
+++ b/src/resolvers/DelTranee.ts
@@ -26,11 +26,14 @@ const traineeResolvers:any={
           async softdeleteTrainee(parent:any,args:any){
             const trainee = await TraineeApplicant.findById(args.input.id);
             if(!trainee) throw new Error("Trainee doesn't exist")
-            const softDelete= await TraineeApplicant.findByIdAndUpdate(args.input.id,{ $set: {delete_at:  true, id:args.input.id}},{ new: true });
-            console.log(softDelete);
-    
-            
+            const softDelete= await TraineeApplicant.findByIdAndUpdate(args.input.id,{ $set: {delete_at:  true, id:args.input.id}},{ new: true });     
             return softDelete;
+          },
+          async softRecover(parent:any,args:any){
+            const trainee = await TraineeApplicant.findById(args.input.id);
+            if(!trainee) throw new Error("Trainee doesn't exist")
+            const softRecovered= await TraineeApplicant.findByIdAndUpdate(args.input.id,{ $set: {delete_at:  false, id:args.input.id}},{ new: true });
+            return softRecovered;
           },
         }
 

--- a/src/resolvers/additionalAttributeField.ts
+++ b/src/resolvers/additionalAttributeField.ts
@@ -1,0 +1,41 @@
+import { additionalAttributesField }  from '../models/additionalAttributes';
+import { traineEAttributes } from '../models/traineeAttribute';
+const additionalAttributesFieldResolver:any={
+    Query: {
+        async getAllAdditionalAttributesFields(){
+            const getAdditionalAttributesFields = await additionalAttributesField.find({});
+            return getAdditionalAttributesFields;
+          },
+         async getAdditionalAttributesField(parent:any, args:any){
+          const getOneAdditionalAttributesField = await additionalAttributesField.findById(args.id)
+          if(!additionalAttributesField) throw new Error("This additionalAttributesField doesn't exist");
+          return getOneAdditionalAttributesField;
+          
+          
+         },
+        },
+         Mutation: {
+            async createAdditionalAttributesField(_parent:any,_args:any) {
+                // const additionalAttributesFieldExists = await additionalAttributesField.findOne({ fieldName: _args.input.id });
+                const searchAttribute = await traineEAttributes
+                .findOne({ trainee_id: _args.input.id })
+                .populate("trainee_id")
+                .exec();
+                if (searchAttribute) {
+                  const newAdditionalAttributesField= await additionalAttributesField.create({fieldName:_args.input.fieldName, keyvalue: _args.input.keyvalue });
+                  // await traineEAttributes.push({ additional_fields : newAdditionalAttributesField});
+                  await traineEAttributes.findOneAndUpdate(
+                    {trainee_id: searchAttribute.trainee_id},
+                    {
+                      additional_fields: newAdditionalAttributesField.id,
+                    },
+                    { new: true }
+                  )
+                  return newAdditionalAttributesField;
+
+                } else throw new Error("This id's attribute doesn't exists!");
+              }
+            }
+   
+}
+export default additionalAttributesFieldResolver

--- a/src/resolvers/traineeAttributeResolver.ts
+++ b/src/resolvers/traineeAttributeResolver.ts
@@ -1,5 +1,6 @@
 import { traineEAttributes } from "../models/traineeAttribute";
 import TraineeApplicant from "../models/traineeApplicant";
+var mongooseDynamic = require ('mongoose-dynamic-schemas');
 
 export const traineeAttributeResolver: any = {
   Query: {
@@ -32,7 +33,7 @@ export const traineeAttributeResolver: any = {
       // console.log("items to skip", itemsToSkip)
       const allTraineeAttribute = await traineEAttributes
         .find({})
-        .populate("trainee_id")
+        .populate("additional_fields").populate("trainee_id")
         .skip(itemsToSkip)
         .limit(items);
       // console.log("attributes", allTraineeAttribute)
@@ -49,6 +50,7 @@ export const traineeAttributeResolver: any = {
       return oneTraineeAttribute;
     },
   },
+
 
   Mutation: {
     async createTraineeAttribute(_: any, args: any) {
@@ -96,11 +98,25 @@ export const traineeAttributeResolver: any = {
           english_score: attributeUpdateInput.english_score,
           interview_decision: attributeUpdateInput.interview_decision,
           past_andela_programs: attributeUpdateInput.past_andela_programs,
+          additional_fields: attributeUpdateInput.additional_fields,
         },
         { new: true }
       );
       // console.log("updated", updated);
       if (!updated)
+        throw new Error("No Trainee is found, please provide the correct trainee_id");
+      return updated;
+    },
+    async addDynamicFields(parent: any, args: any, context: any) {
+      const { ID ,addFieldsToTraineeAttributeInput} = args;
+
+      const updated = await traineEAttributes.findOneAndUpdate(
+        {trainee_id: ID},
+        {$set: {[addFieldsToTraineeAttributeInput.field_name] : `${addFieldsToTraineeAttributeInput.key_value}` }},
+        {strict: false},
+      );
+      // console.log("updated", updated);
+      if (!ID)
         throw new Error("No Trainee is found, please provide the correct trainee_id");
       return updated;
     },

--- a/src/schema/additionalFiledsTypeDefs.ts
+++ b/src/schema/additionalFiledsTypeDefs.ts
@@ -1,0 +1,32 @@
+import { gql } from "apollo-server";
+export const typeDefsAdditionalFields = gql`
+  type Query {
+    getAllAdditionalAttributesFields: [additionalField]!
+    getAdditionalAttributesField(ID:ID!): additionalField!
+  }
+  type Mutation {
+    createAdditionalAttributesField(input: newAdditionalFieldInput): additionalField!
+    updateAdditionalField(ID:ID!, updateInput: AdditionalFieldInputUpdate): additionalField
+    deleteAdditionalField(ID: ID!): additionalField!
+  }
+  type additionalField {
+    fieldName: String!
+    keyvalue: String!
+    _id: ID!
+  }
+
+  input newAdditionalFieldInput {
+    fieldName: String!
+    keyvalue: String!
+    id:String!
+  }
+  input deleteAdditionalField{
+    id:ID!
+ }
+
+  input AdditionalFieldInputUpdate {
+    fieldName: String
+    keyvalue: String
+    id:String
+  }
+`;

--- a/src/schema/deleteTraineTypeDefs.ts
+++ b/src/schema/deleteTraineTypeDefs.ts
@@ -14,6 +14,11 @@ input softdeleteTrainee{
     delete_at:Boolean
     
 }
+input softRecover{
+    id:ID!
+    delete_at:Boolean
+    
+}
 input deleteTrainee{
     id:ID!
 }
@@ -26,6 +31,7 @@ type Query{
 type Mutation {
     deleteTrainee(id:ID!):Trainee!
     softdeleteTrainee(input: softdeleteTrainee ):Trainee!
+    softRecover(input: softRecover ):Trainee!
 }
 `
 export default Schema

--- a/src/schema/traineeAttributeSchema.ts
+++ b/src/schema/traineeAttributeSchema.ts
@@ -7,6 +7,8 @@ type Query {
 type Mutation {
 	createTraineeAttribute(attributeInput: traineeAttributeInput): traineeAttributeCreated
 	updateTraineeAttribute(ID:ID!, attributeUpdateInput: traineeUpdateAttributeInput): traineeAttributeCreated
+	addDynamicFields(ID:ID!, addFieldsToTraineeAttributeInput: traineeNewFieldsInput): traineeAttributeCreated
+
 }
 input one {id: ID!}
     
@@ -19,8 +21,8 @@ input one {id: ID!}
 	input traineeAttributeInput {
 		gender: String!
 		birth_date: String!
-         Address: String!
-         phone: String!
+        Address: String!
+        phone: String!
         field_of_study: String!
         education_level: String!
         province: String!
@@ -35,6 +37,8 @@ input one {id: ID!}
         interview_decision: String!
         past_andela_programs: String!
         trainee_id: String!
+        additional_fields: String!
+
 	}
 	input traineeUpdateAttributeInput {
 		gender: String
@@ -54,6 +58,8 @@ input one {id: ID!}
         english_score: String
         interview_decision: String
         past_andela_programs: String
+        additional_fields: String
+        
 	}
 
 	type traineeAttribute {
@@ -74,9 +80,22 @@ input one {id: ID!}
         english_score: String!
         interview_decision: String!
         past_andela_programs: String!
-        _id:ID
+        _id:ID!
 		trainee_id: traineeApplicant!
+        additional_fields: additionalField!
+        # push(newAdditionalAttributesField)
 	}
+
+    input traineeNewFieldsInput {
+            field_name: String!
+            key_value: String!
+    }
+      type traineeNewFields {
+            field_name: String!
+            key_value: String!
+    }
+
+
 
     	type traineeAttributeCreated {
         gender: String!
@@ -96,7 +115,8 @@ input one {id: ID!}
         english_score: String!
         interview_decision: String!
         past_andela_programs: String!
-        _id:ID
+        _id:ID!
 		trainee_id: String!
+        additional_fields: String!
 	}
 `


### PR DESCRIPTION
### **What does this PR do?**
analyze of our trainee's attribute collections is designed to be dynamic: we can add a new field for any new trainee;

### **How should this be manually tested?**

• Run `git clone https://github.com/atlp-rwanda/atlp-devpulse-bn` to clone the project

• Run `cd atlp-devpulse-bn` to go to the root project

• Run `git checkout ft-dynamic-fields`

• Run `npm i` or `npm install `l to install all used dependencies

• Run `npm run dev` to start the server
### **What to expect?**
To dynamically add new fields

![mutate-new-dynamic](https://user-images.githubusercontent.com/81898585/203311180-e00cadc3-2ce8-4092-a778-b678df7d45e0.png)
![querry-additional](https://user-images.githubusercontent.com/81898585/203311200-f6f7d1f4-cd5e-439b-9deb-84126c044e61.png)
