### PR TITLE
Fix: Improving performance on importing many trainees from google sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "ts-node-dev": "^2.0.0"
       },
       "devDependencies": {
+        "apollo-server-core": "^3.11.1",
         "nodemon": "^2.0.19",
         "ts-node": "^10.9.1",
         "typescript": "^4.8.3"
@@ -620,9 +621,10 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.3.tgz",
-      "integrity": "sha512-PiTirlcaszgnJGzSsGui9XWh0KAh0BUW+GvRKN6O0H0qOSXSLmoqqyL83J+u+HaUZGyyiE0+VOkyCcuF+kKbEw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.11.1.tgz",
+      "integrity": "sha512-t/eCKrRFK1lYZlc5pHD99iG7Np7CEm3SmbDiONA7fckR3EaB/pdsEdIkIwQ5QBBpT5JLp/nwvrZRVwhaWmaRvw==",
+      "deprecated": "The `apollo-server-core` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -636,13 +638,14 @@
         "apollo-reporting-protobuf": "^3.3.3",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.6.3",
-        "apollo-server-types": "^3.6.3",
+        "apollo-server-plugin-base": "^3.7.1",
+        "apollo-server-types": "^3.7.1",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -702,11 +705,12 @@
       }
     },
     "node_modules/apollo-server-plugin-base": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.3.tgz",
-      "integrity": "sha512-/Q0Zx8N8La97faKV0siGHDzfZ56ygN6ovtUpPbr+1GIbNmUzkte3lWW2YV08HmxiRmC2i2OGN80exNJEvbKvNA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz",
+      "integrity": "sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ==",
+      "deprecated": "The `apollo-server-plugin-base` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
-        "apollo-server-types": "^3.6.3"
+        "apollo-server-types": "^3.7.1"
       },
       "engines": {
         "node": ">=12.0"
@@ -716,9 +720,10 @@
       }
     },
     "node_modules/apollo-server-types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.3.tgz",
-      "integrity": "sha512-+7caNTLdevpWI2dGKSa7CWdyudO3NBuJ3HzcrYxjBei6Bth9YdRUNzPSFmBjlm2baHF0GsrMwLpjO+HStJzm3A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.7.1.tgz",
+      "integrity": "sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw==",
+      "deprecated": "The `apollo-server-types` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -1837,6 +1842,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -3158,9 +3168,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.3.tgz",
-      "integrity": "sha512-PiTirlcaszgnJGzSsGui9XWh0KAh0BUW+GvRKN6O0H0qOSXSLmoqqyL83J+u+HaUZGyyiE0+VOkyCcuF+kKbEw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.11.1.tgz",
+      "integrity": "sha512-t/eCKrRFK1lYZlc5pHD99iG7Np7CEm3SmbDiONA7fckR3EaB/pdsEdIkIwQ5QBBpT5JLp/nwvrZRVwhaWmaRvw==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -3174,13 +3184,14 @@
         "apollo-reporting-protobuf": "^3.3.3",
         "apollo-server-env": "^4.2.1",
         "apollo-server-errors": "^3.3.1",
-        "apollo-server-plugin-base": "^3.6.3",
-        "apollo-server-types": "^3.6.3",
+        "apollo-server-plugin-base": "^3.7.1",
+        "apollo-server-types": "^3.7.1",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.1.0",
         "graphql-tag": "^2.11.0",
         "loglevel": "^1.6.8",
         "lru-cache": "^6.0.0",
+        "node-abort-controller": "^3.0.1",
         "sha.js": "^2.4.11",
         "uuid": "^9.0.0",
         "whatwg-mimetype": "^3.0.0"
@@ -3219,17 +3230,17 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.3.tgz",
-      "integrity": "sha512-/Q0Zx8N8La97faKV0siGHDzfZ56ygN6ovtUpPbr+1GIbNmUzkte3lWW2YV08HmxiRmC2i2OGN80exNJEvbKvNA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz",
+      "integrity": "sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ==",
       "requires": {
-        "apollo-server-types": "^3.6.3"
+        "apollo-server-types": "^3.7.1"
       }
     },
     "apollo-server-types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.3.tgz",
-      "integrity": "sha512-+7caNTLdevpWI2dGKSa7CWdyudO3NBuJ3HzcrYxjBei6Bth9YdRUNzPSFmBjlm2baHF0GsrMwLpjO+HStJzm3A==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.7.1.tgz",
+      "integrity": "sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -4047,6 +4058,11 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-abort-controller": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
+      "integrity": "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
     },
     "node-fetch": {
       "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/atlp-rwanda/atlp-devpulse-bn#readme",
   "devDependencies": {
+    "apollo-server-core": "^3.11.1",
     "nodemon": "^2.0.19",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import ResendDataSchema from "./schema/resendDataIntoDbTypeDefs";
 ;
 import scoreTypeResolver from "./resolvers/scoreTypesResolvers";
 import scoreValuesResolver from "./resolvers/scoreValuesResolvers";
+import { ApolloServerPluginInlineTrace } from "apollo-server-core";
 
 const PORT = process.env.PORT || 3000;
 
@@ -61,6 +62,7 @@ const server = new ApolloServer({
   resolvers,
   introspection: true,
   csrfPrevention: true,
+  plugins: [ApolloServerPluginInlineTrace()],
   // cache: "bounded",
 });
 

--- a/src/resolvers/traineeResolvers.ts
+++ b/src/resolvers/traineeResolvers.ts
@@ -66,43 +66,57 @@ const loadTraineeResolver: any = {
           "cycle_name",
         ];
 
-        const getIndexArrOfTheTrainee = (correctColumnOfProperty: string[]) => {
-          const arrayOfTraineeProperties = ["firstName", "lastName", "email"];
-          const traineeIndexArray = [];
-          for (let i = 0; i < arrayOfTraineeProperties.length; i++) {
-            // @ts-ignore
-            if (correctColumnOfProperty.includes(arrayOfTraineeProperties[i])) {
-              // @ts-ignore
-              const index = correctColumnOfProperty.indexOf(
-                arrayOfTraineeProperties[i]
-              );
-              traineeIndexArray.push(index);
-            }
-          }
-          return traineeIndexArray;
-        };
+        // const getIndexArrOfTheTrainee = (correctColumnOfProperty: string[]) => {
+        //   const arrayOfTraineeProperties = ["firstName", "lastName", "email"];
+        //   const traineeIndexArray = [];
+        //   for (let i = 0; i < arrayOfTraineeProperties.length; i++) {
+        //     // @ts-ignore
+        //     if (correctColumnOfProperty.includes(arrayOfTraineeProperties[i])) {
+        //       // @ts-ignore
+        //       const index = correctColumnOfProperty.indexOf(
+        //         arrayOfTraineeProperties[i]
+        //       );
+        //       traineeIndexArray.push(index);
+        //     }
 
-        const giveMeDataInACorrectFormatTrainee = (
-          arrOfAllRows: any,
-          correctColumnArr: any,
-          arrOfTraineeIndexes: any
-        ) => {
-          const arrOfObject = [];
-          for (let i = 1; i < arrOfAllRows.length; i++) {
-            arrOfObject.push({
-              [correctColumnArr[arrOfTraineeIndexes[0]]]:
-                arrOfAllRows[i][arrOfTraineeIndexes[0]],
-              [correctColumnArr[arrOfTraineeIndexes[1]]]:
-                arrOfAllRows[i][arrOfTraineeIndexes[1]],
-              [correctColumnArr[arrOfTraineeIndexes[2]]]:
-                arrOfAllRows[i][arrOfTraineeIndexes[2]],
-            });
-          }
-          return arrOfObject;
-        };
+        //     // If the indexes of trainees is yet captured, do not continue to iterate on the array,
+        //     // JUST GO OUT OF THE LOOP as the purpose of iterating is already achieved!
+        //     if (traineeIndexArray.length === 3) continue
+        //   }
+        //   return traineeIndexArray;
+        // };
 
+        // const giveMeDataInACorrectFormatTrainee = (
+        //   arrOfAllRows: any,
+        //   correctColumnArr: any,
+        //   arrOfTraineeIndexes: any
+        // ) => {
+        //   const arrOfObject = [];
+
+        //   for (let i = 1; i < arrOfAllRows.length; i++) {
+        //     // th data format of arrOfAllRows is
+        //     // As the length of the indexes of the array is well known and should be three as it is representing,
+        //     // three datafields; email, firstName and secondName. so we can get them automatically by accessing them
+        //     // through index 0, 1, 2.
+        //     arrOfObject.push({
+        //       [correctColumnArr[arrOfTraineeIndexes[0]]]:
+        //         arrOfAllRows[i][arrOfTraineeIndexes[0]],
+        //       [correctColumnArr[arrOfTraineeIndexes[1]]]:
+        //         arrOfAllRows[i][arrOfTraineeIndexes[1]],
+        //       [correctColumnArr[arrOfTraineeIndexes[2]]]:
+        //         arrOfAllRows[i][arrOfTraineeIndexes[2]],
+        //     });
+        //   }
+        //   return arrOfObject;
+        // };
+
+        // some of the data received from the table contains the yes or no values while in the database schema
+        // it is declared as boolean either true or false. So this function is there to loop through them
+        // and replace true or false where it found yes or no.
         const replaceNoOrYesWithTrueOrFalseFunc = (dataObject: any) => {
           let finObject = { ...dataObject };
+          // note that since the datafields which normally receives the no or yes response are known,
+          // we can hardcode them and they are : isEmployed, haveLaptop, isStudent.
           if (dataObject.isEmployed.toLowerCase() === "no") {
             finObject = {
               ...finObject,
@@ -142,7 +156,7 @@ const loadTraineeResolver: any = {
           return finObject;
         };
 
-        const giveMeDataInACorrectFormatAttributes = (
+        const giveMeDataOfAttributesAndTraineesSeparately = (
           arr: any,
           arrOfCorrectColumnProperties: any
         ) => {
@@ -173,24 +187,68 @@ const loadTraineeResolver: any = {
             });
           }
           // @ts-ignore
-          const arrOfAttributesData = arrOfObject.map((item: any) => {
-            delete item["firstName"];
-            delete item["lastName"];
-            delete item["email"];
-            const cycle_id = item["cycle_name"];
-            delete item["cycle_name"];
-            const attributesObject = replaceNoOrYesWithTrueOrFalseFunc(item);
-            return {
+
+          const arrOfTraineesAndAttributes = [];
+          for (let Item of arrOfObject) {
+            // @ts-ignore
+            const cycle_id = Item["cycle_name"];
+            // create the object of the trainees swapped from the general
+            // object containing all of the datas from the table
+            const traineesObject = {
+              // @ts-ignore
+              firstName: Item.firstName,
+              // @ts-ignore
+              lastName: Item.lastName,
+              // @ts-ignore
+              email: Item.email,
+            };
+            // Remove the ones which pertains to the trainees, which are email, firstName and lastName.
+            // @ts-ignore
+            delete Item["firstName"];
+            // @ts-ignore
+            delete Item["lastName"];
+            // @ts-ignore
+            delete Item["email"];
+            // @ts-ignore
+            delete Item["cycle_name"];
+            // go to replace the no or  yes values with the true and false values as they are the ones which are required
+            // when saving them in the database
+            const attributesObject = replaceNoOrYesWithTrueOrFalseFunc(Item);
+            arrOfTraineesAndAttributes.push({
+              trainees: traineesObject,
               attributes: attributesObject,
               cycle_id: cycle_id,
-            };
-          });
+            });
+          }
 
-          return arrOfAttributesData;
+          // const arrOfTraineesAndAttributes = arrOfObject.map((item: any) => {
+          //   const cycle_id = item["cycle_name"];
+          //   // create the object of the trainees swapped from the general
+          //   // object containing all of the datas from the table
+          //   const traineesObject = {
+          //     firstName: item.firstName,
+          //     lastName: item.lastName,
+          //     email: item.email,
+          //   };
+          //   // Remove the ones which pertains to the trainees, which are email, firstName and lastName.
+          //   delete item["firstName"];
+          //   delete item["lastName"];
+          //   delete item["email"];
+          //   delete item["cycle_name"];
+          //   // go to replace the no or  yes values with the true and false values as they are the ones which are required
+          //   // when saving them in the database
+          //   const attributesObject = replaceNoOrYesWithTrueOrFalseFunc(item);
+          //   return {
+          //     trainees: traineesObject,
+          //     attributes: attributesObject,
+          //     cycle_id: cycle_id,
+          //   };
+          // });
+
+          return arrOfTraineesAndAttributes;
         };
 
         const SPValuesArr: any = rows.data.values;
-
 
         let newErrorArr: any = [0][0];
         let retunedNewUnmached: any = [];
@@ -209,16 +267,11 @@ const loadTraineeResolver: any = {
           // but if there is no error just save them or him into database.
           // @ts-ignore
           const correctColumn = rows?.data?.values[0];
-          const indexes = getIndexArrOfTheTrainee(correctColumn);
-          const traineeArray = giveMeDataInACorrectFormatTrainee(
-            rows?.data?.values,
-            correctColumn,
-            indexes
-          );
-          const attributesArray = giveMeDataInACorrectFormatAttributes(
-            rows?.data?.values,
-            correctColumn
-          );
+          const attributesAndTraineesArray =
+            giveMeDataOfAttributesAndTraineesSeparately(
+              rows?.data?.values,
+              correctColumn
+            );
 
           // @ts-ignore
           const promisesForCycles = [];
@@ -229,7 +282,7 @@ const loadTraineeResolver: any = {
             // find cycles  and return just _id field only because it is what is need ONLY
             const cycle = applicationCycle.findOne(
               {
-                name: attributesArray[i].cycle_id,
+                name: attributesAndTraineesArray[i].cycle_id,
               },
               {
                 projection: { _id: 1 },
@@ -239,51 +292,25 @@ const loadTraineeResolver: any = {
           }
           const cycles = await Promise.all(promisesForCycles);
 
+          // loop through all of the data in the array and save them but INSTEAD OF AWAITING ALL OF THEM EACH TIME,
+          // use promise.all to await all of them at once after loop.
           for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-
-            const trainee = TraineeApplicant.create(
-              {
-                ...traineeArray[i],
-                cycle_id: cycles[i]?._id,
-              }
-            );
+            const trainee = TraineeApplicant.create({
+              ...attributesAndTraineesArray[i].trainees,
+              cycle_id: cycles[i]?._id,
+            });
             promisesForTrainees.push(trainee);
           }
           const trainees = await Promise.all(promisesForTrainees);
 
-            for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-                const traineeAttribute = traineEAttributes.create(
-                {
-                  ...attributesArray[i].attributes,
-                  trainee_id: trainees[i]._id,
-                }
-                );
-                promisesForAttributes.push(traineeAttribute);
-            }
-            const attributes = await Promise.all(promisesForAttributes);
-
-          // for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-          //       const cycle = await applicationCycle.findOne({
-          //         name: attributesArray[i].cycle_id,
-          //       });
-          //       if (!cycle) {
-          //         throw new Error("Wrong cycle name is provided!!!!")
-          //       }
-          //       const trainee = new TraineeApplicant({
-          //         ...traineeArray[i],
-          //         cycle_id: cycle?._id,
-          //       });
-          //       await trainee.save();
-          //       const traineeAttributeObj = {
-          //         ...attributesArray[i].attributes,
-          //         trainee_id: trainee._id,
-          //       };
-
-          //   const traineeAttributes = new traineEAttributes(
-          //     traineeAttributeObj
-          //   );
-          //   await traineeAttributes.save();
-          // }
+          for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+            const traineeAttribute = traineEAttributes.create({
+              ...attributesAndTraineesArray[i].attributes,
+              trainee_id: trainees[i]._id,
+            });
+            promisesForAttributes.push(traineeAttribute);
+          }
+          const attributes = await Promise.all(promisesForAttributes);
         }
 
         return "Trainees data loaded to db successfully";
@@ -327,43 +354,6 @@ const loadTraineeResolver: any = {
         }
         return firstRowColumnArr;
       };
-
-      const getIndexArrOfTheTrainee = (correctColumnOfProperty: string[]) => {
-        const arrayOfTraineeProperties = ["firstName", "lastName", "email"];
-        const traineeIndexArray = [];
-        for (let i = 0; i < arrayOfTraineeProperties.length; i++) {
-          // @ts-ignore
-          if (correctColumnOfProperty.includes(arrayOfTraineeProperties[i])) {
-            // @ts-ignore
-            const index = correctColumnOfProperty.indexOf(
-              arrayOfTraineeProperties[i]
-            );
-            traineeIndexArray.push(index);
-          }
-        }
-        return traineeIndexArray;
-      };
-
-      const giveMeDataInACorrectFormatTrainee = (
-        arrOfAllRows: any,
-        correctColumnArr: any,
-        arrOfTraineeIndexes: any
-      ) => {
-        // [1,8,12]
-        const arrOfObject = [];
-        for (let i = 1; i < arrOfAllRows.length; i++) {
-          arrOfObject.push({
-            [correctColumnArr[arrOfTraineeIndexes[0]]]:
-              arrOfAllRows[i][arrOfTraineeIndexes[0]],
-            [correctColumnArr[arrOfTraineeIndexes[1]]]:
-              arrOfAllRows[i][arrOfTraineeIndexes[1]],
-            [correctColumnArr[arrOfTraineeIndexes[2]]]:
-              arrOfAllRows[i][arrOfTraineeIndexes[2]],
-          });
-        }
-        return arrOfObject;
-      };
-      // [arr[0][3]]
       const replaceNoOrYesWithTrueOrFalseFunc = (dataObject: any) => {
         let finObject = { ...dataObject };
         if (dataObject.isEmployed.toLowerCase() === "no") {
@@ -404,8 +394,7 @@ const loadTraineeResolver: any = {
         }
         return finObject;
       };
-
-      const giveMeDataInACorrectFormatAttributes = (
+      const giveMeDataOfAttributesAndTraineesSeparately = (
         arr: any,
         arrOfCorrectColumnProperties: any
       ) => {
@@ -435,40 +424,51 @@ const loadTraineeResolver: any = {
             [arrOfCorrectColumnProperties[2]]: arr[i][2],
           });
         }
-        const arrOfAttributesData = arrOfObject.map((item: any) => {
-          delete item["firstName"];
-          delete item["lastName"];
-          delete item["email"];
-          let cycle_id = "";
-          if (columnData["cycle_name"] === "") {
-            cycle_id = item["cycle_name"];
-          } else {
-            cycle_id = columnData["cycle_name"];
-          }
-          delete item["cycle_name"];
-          const attributesObject = replaceNoOrYesWithTrueOrFalseFunc(item);
-          return {
+        // @ts-ignore
+
+        const arrOfTraineesAndAttributes = [];
+        for (let Item of arrOfObject) {
+          // @ts-ignore
+          const cycle_id = Item["cycle_name"];
+          // create the object of the trainees swapped from the general
+          // object containing all of the datas from the table
+          const traineesObject = {
+            // @ts-ignore
+            firstName: Item.firstName,
+            // @ts-ignore
+            lastName: Item.lastName,
+            // @ts-ignore
+            email: Item.email,
+          };
+          // Remove the ones which pertains to the trainees, which are email, firstName and lastName.
+          // @ts-ignore
+          delete Item["firstName"];
+          // @ts-ignore
+          delete Item["lastName"];
+          // @ts-ignore
+          delete Item["email"];
+          // @ts-ignore
+          delete Item["cycle_name"];
+          // go to replace the no or  yes values with the true and false values as they are the ones which are required
+          // when saving them in the database
+          const attributesObject = replaceNoOrYesWithTrueOrFalseFunc(Item);
+          arrOfTraineesAndAttributes.push({
+            trainees: traineesObject,
             attributes: attributesObject,
             cycle_id: cycle_id,
-          };
-        });
-
-        return arrOfAttributesData;
+          });
+        }
+        return arrOfTraineesAndAttributes;
       };
 
       // @ts-ignore
       const correctColumn = replaceToGetCorrectColumn(rows?.data?.values[0]);
-      const indexes = getIndexArrOfTheTrainee(correctColumn);
-      const traineeArray = giveMeDataInACorrectFormatTrainee(
-        rows?.data?.values,
-        correctColumn,
-        indexes
-      );
-      const attributesArray = giveMeDataInACorrectFormatAttributes(
-        rows?.data?.values,
-        correctColumn
-      );
-
+      
+      const attributesAndTraineesArray =
+        giveMeDataOfAttributesAndTraineesSeparately(
+          rows?.data?.values,
+          correctColumn
+        );
       const promisesForCycles = [];
       const promisesForTrainees = [];
       const promisesForAttributes = [];
@@ -477,7 +477,7 @@ const loadTraineeResolver: any = {
         // find cycles  and return just _id field only because it is what is need ONLY
         const cycle = applicationCycle.findOne(
           {
-            name: attributesArray[i].cycle_id,
+            name: attributesAndTraineesArray[i].cycle_id,
           },
           {
             projection: { _id: 1 },
@@ -489,7 +489,7 @@ const loadTraineeResolver: any = {
       // @ts-ignore
       for (let i = 0; i < rows.data?.values?.length - 1; i++) {
         const trainee = TraineeApplicant.create({
-          ...traineeArray[i],
+          ...attributesAndTraineesArray[i].trainees,
           cycle_id: cycles[i]?._id,
         });
         promisesForTrainees.push(trainee);
@@ -498,30 +498,12 @@ const loadTraineeResolver: any = {
       // @ts-ignore
       for (let i = 0; i < rows.data?.values?.length - 1; i++) {
         const traineeAttribute = traineEAttributes.create({
-          ...attributesArray[i].attributes,
+          ...attributesAndTraineesArray[i].attributes,
           trainee_id: trainees[i]._id,
         });
         promisesForAttributes.push(traineeAttribute);
       }
       const attributes = await Promise.all(promisesForAttributes);
-      // save the trainee to the database
-      // @ts-ignore
-      // for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-      //     const cycle = await applicationCycle.findOne({name:attributesArray[i].cycle_id});
-      //      if (!cycle) {
-      //        throw new Error("Wrong cycle name is provided!!!!");
-      //      }
-      //   const trainee = new TraineeApplicant({
-      //     ...traineeArray[i],
-      //     cycle_id: cycle?._id,
-      //   });
-      //   await trainee.save();
-      //   const traineeAttributeObj = {
-      //     ...attributesArray[i].attributes,
-      //     trainee_id: trainee._id,
-      //   };
-      //   const traineeAttributes = new traineEAttributes(traineeAttributeObj);
-      //   await traineeAttributes.save();
       // }
       return "The data mapped has been saved successfully, CONGRATS";
     },

--- a/src/resolvers/traineeResolvers.ts
+++ b/src/resolvers/traineeResolvers.ts
@@ -220,28 +220,70 @@ const loadTraineeResolver: any = {
             correctColumn
           );
 
-          for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-                const cycle = await applicationCycle.findOne({
-                  name: attributesArray[i].cycle_id,
-                });
-                if (!cycle) {
-                  throw new Error("Wrong cycle name is provided!!!!")
-                }
-                const trainee = new TraineeApplicant({
-                  ...traineeArray[i],
-                  cycle_id: cycle?._id,
-                });
-                await trainee.save();
-                const traineeAttributeObj = {
-                  ...attributesArray[i].attributes,
-                  trainee_id: trainee._id,
-                };
+          // @ts-ignore
+          const promisesForCycles = [];
+          const promisesForTrainees = [];
+          const promisesForAttributes = [];
 
-            const traineeAttributes = new traineEAttributes(
-              traineeAttributeObj
+          for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+            // find cycles  and return just _id field only because it is what is need ONLY
+            const cycle = applicationCycle.findOne(
+              {
+                name: attributesArray[i].cycle_id,
+              },
+              {
+                projection: { _id: 1 },
+              }
             );
-            await traineeAttributes.save();
+            promisesForCycles.push(cycle);
           }
+          const cycles = await Promise.all(promisesForCycles);
+
+          for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+
+            const trainee = TraineeApplicant.create(
+              {
+                ...traineeArray[i],
+                cycle_id: cycles[i]?._id,
+              }
+            );
+            promisesForTrainees.push(trainee);
+          }
+          const trainees = await Promise.all(promisesForTrainees);
+
+            for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+                const traineeAttribute = traineEAttributes.create(
+                {
+                  ...attributesArray[i].attributes,
+                  trainee_id: trainees[i]._id,
+                }
+                );
+                promisesForAttributes.push(traineeAttribute);
+            }
+            const attributes = await Promise.all(promisesForAttributes);
+
+          // for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+          //       const cycle = await applicationCycle.findOne({
+          //         name: attributesArray[i].cycle_id,
+          //       });
+          //       if (!cycle) {
+          //         throw new Error("Wrong cycle name is provided!!!!")
+          //       }
+          //       const trainee = new TraineeApplicant({
+          //         ...traineeArray[i],
+          //         cycle_id: cycle?._id,
+          //       });
+          //       await trainee.save();
+          //       const traineeAttributeObj = {
+          //         ...attributesArray[i].attributes,
+          //         trainee_id: trainee._id,
+          //       };
+
+          //   const traineeAttributes = new traineEAttributes(
+          //     traineeAttributeObj
+          //   );
+          //   await traineeAttributes.save();
+          // }
         }
 
         return "Trainees data loaded to db successfully";
@@ -427,25 +469,60 @@ const loadTraineeResolver: any = {
         correctColumn
       );
 
-      // save the trainee to the database
+      const promisesForCycles = [];
+      const promisesForTrainees = [];
+      const promisesForAttributes = [];
       // @ts-ignore
       for (let i = 0; i < rows.data?.values?.length - 1; i++) {
-          const cycle = await applicationCycle.findOne({name:attributesArray[i].cycle_id});
-           if (!cycle) {
-             throw new Error("Wrong cycle name is provided!!!!");
-           }
-        const trainee = new TraineeApplicant({
-          ...traineeArray[i],
-          cycle_id: cycle?._id,
-        });
-        await trainee.save();
-        const traineeAttributeObj = {
-          ...attributesArray[i].attributes,
-          trainee_id: trainee._id,
-        };
-        const traineeAttributes = new traineEAttributes(traineeAttributeObj);
-        await traineeAttributes.save();
+        // find cycles  and return just _id field only because it is what is need ONLY
+        const cycle = applicationCycle.findOne(
+          {
+            name: attributesArray[i].cycle_id,
+          },
+          {
+            projection: { _id: 1 },
+          }
+        );
+        promisesForCycles.push(cycle);
       }
+      const cycles = await Promise.all(promisesForCycles);
+      // @ts-ignore
+      for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+        const trainee = TraineeApplicant.create({
+          ...traineeArray[i],
+          cycle_id: cycles[i]?._id,
+        });
+        promisesForTrainees.push(trainee);
+      }
+      const trainees = await Promise.all(promisesForTrainees);
+      // @ts-ignore
+      for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+        const traineeAttribute = traineEAttributes.create({
+          ...attributesArray[i].attributes,
+          trainee_id: trainees[i]._id,
+        });
+        promisesForAttributes.push(traineeAttribute);
+      }
+      const attributes = await Promise.all(promisesForAttributes);
+      // save the trainee to the database
+      // @ts-ignore
+      // for (let i = 0; i < rows.data?.values?.length - 1; i++) {
+      //     const cycle = await applicationCycle.findOne({name:attributesArray[i].cycle_id});
+      //      if (!cycle) {
+      //        throw new Error("Wrong cycle name is provided!!!!");
+      //      }
+      //   const trainee = new TraineeApplicant({
+      //     ...traineeArray[i],
+      //     cycle_id: cycle?._id,
+      //   });
+      //   await trainee.save();
+      //   const traineeAttributeObj = {
+      //     ...attributesArray[i].attributes,
+      //     trainee_id: trainee._id,
+      //   };
+      //   const traineeAttributes = new traineEAttributes(traineeAttributeObj);
+      //   await traineeAttributes.save();
+      // }
       return "The data mapped has been saved successfully, CONGRATS";
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,10 +423,10 @@
   dependencies:
     "@apollo/protobufjs" "1.2.6"
 
-"apollo-server-core@^3.10.3":
-  "integrity" "sha512-PiTirlcaszgnJGzSsGui9XWh0KAh0BUW+GvRKN6O0H0qOSXSLmoqqyL83J+u+HaUZGyyiE0+VOkyCcuF+kKbEw=="
-  "resolved" "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.3.tgz"
-  "version" "3.10.3"
+"apollo-server-core@^3.10.3", "apollo-server-core@^3.11.1":
+  "integrity" "sha512-t/eCKrRFK1lYZlc5pHD99iG7Np7CEm3SmbDiONA7fckR3EaB/pdsEdIkIwQ5QBBpT5JLp/nwvrZRVwhaWmaRvw=="
+  "resolved" "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.11.1.tgz"
+  "version" "3.11.1"
   dependencies:
     "@apollo/utils.keyvaluecache" "^1.0.1"
     "@apollo/utils.logger" "^1.0.0"
@@ -440,13 +440,14 @@
     "apollo-reporting-protobuf" "^3.3.3"
     "apollo-server-env" "^4.2.1"
     "apollo-server-errors" "^3.3.1"
-    "apollo-server-plugin-base" "^3.6.3"
-    "apollo-server-types" "^3.6.3"
+    "apollo-server-plugin-base" "^3.7.1"
+    "apollo-server-types" "^3.7.1"
     "async-retry" "^1.2.1"
     "fast-json-stable-stringify" "^2.1.0"
     "graphql-tag" "^2.11.0"
     "loglevel" "^1.6.8"
     "lru-cache" "^6.0.0"
+    "node-abort-controller" "^3.0.1"
     "sha.js" "^2.4.11"
     "uuid" "^9.0.0"
     "whatwg-mimetype" "^3.0.0"
@@ -480,17 +481,17 @@
     "cors" "^2.8.5"
     "parseurl" "^1.3.3"
 
-"apollo-server-plugin-base@^3.6.3":
-  "integrity" "sha512-/Q0Zx8N8La97faKV0siGHDzfZ56ygN6ovtUpPbr+1GIbNmUzkte3lWW2YV08HmxiRmC2i2OGN80exNJEvbKvNA=="
-  "resolved" "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.3.tgz"
-  "version" "3.6.3"
+"apollo-server-plugin-base@^3.7.1":
+  "integrity" "sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ=="
+  "resolved" "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz"
+  "version" "3.7.1"
   dependencies:
-    "apollo-server-types" "^3.6.3"
+    "apollo-server-types" "^3.7.1"
 
-"apollo-server-types@^3.6.3":
-  "integrity" "sha512-+7caNTLdevpWI2dGKSa7CWdyudO3NBuJ3HzcrYxjBei6Bth9YdRUNzPSFmBjlm2baHF0GsrMwLpjO+HStJzm3A=="
-  "resolved" "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.6.3.tgz"
-  "version" "3.6.3"
+"apollo-server-types@^3.6.3", "apollo-server-types@^3.7.1":
+  "integrity" "sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw=="
+  "resolved" "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-3.7.1.tgz"
+  "version" "3.7.1"
   dependencies:
     "@apollo/utils.keyvaluecache" "^1.0.1"
     "@apollo/utils.logger" "^1.0.0"
@@ -858,11 +859,6 @@
   "integrity" "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
-
-"fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
@@ -1274,6 +1270,11 @@
   "integrity" "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
   "resolved" "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   "version" "0.6.3"
+
+"node-abort-controller@^3.0.1":
+  "integrity" "sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw=="
+  "resolved" "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz"
+  "version" "3.0.1"
 
 "node-fetch@^2.6.7":
   "integrity" "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ=="


### PR DESCRIPTION
## What does this PR do?

Improving the performance of the uploading datas from the google sheet to the database **whereby the speed is increased up 30 times faster**.

## Description of Task to be completed?

The uploading of the 500 trainees from the google sheet used to take up to 8 min but now it is taking only 24 sec.
The uploading of the 12000 trainees from the google sheet is now taking only 5 min from more than an hour previously.

## How should this be manually tested?

- `Clone the repo`

- `checkout` to branch `ft-improving-performance-on-importing-many-trainees-from-googlesheet`

- Pull the changes by `git pull`

- Install all packages by running `npm install`

- Copy the `url string from the google sheet which is shared to app email` and **remember to change the connection string to your `mongo db connection string`**

- Start app by `running npm run dev`

## Any background context you want to provide?
N/A

## What are the relevant pivotal tracker stories?
[Trello Board reference]()
