### PR TITLE
super-admin and amin should be able to view assessements

### DIFF
--- a/src/models/scoreTypesModel.ts
+++ b/src/models/scoreTypesModel.ts
@@ -1,42 +1,87 @@
-import mongoose, { model, Schema } from "mongoose";
-const scoreTypesModel = mongoose.model(
-  "Scores",
-  new Schema({
-    title:{
-      type:String,
-      required:true,
-      unique:true
-    },
-    description:{
-      type:String,
-      required:true
-    },
-    modeOfEngagement:{
-      type:String,
-      required:true
-    },
-    duration:{
-      type:String,
-      required:true
-    }
-    ,
-    startDate:{
-      type:Date,
-      default:null
-    },
-    endDate:{
-      type:Date,
-      default:null
-    },
-    program: {
-      type: Schema.Types.ObjectId,
-      ref: "ProgramModel", // Reference to the 'Role' model
-    },
+import mongoose, { Schema, Document } from "mongoose";
+
+// Define a TypeScript interface for the scoreType document
+interface IScoreType extends Document {
+  title: string;
+  description: string;
+  modeOfEngagement: string;
+  duration: number;
+  startDate: Date | null;
+  endDate: Date | null;
+  program: mongoose.Types.ObjectId;
+  durationUnit:string;
+  grading:String;
+}
+
+const scoreTypeSchema = new Schema<IScoreType>({
+  title: {
+    type: String,
+    required: true,
+    unique: true,
   },
-  {
-    timestamps:true
+  description: {
+    type: String,
+    required: true,
+  },
+  modeOfEngagement: {
+    type: String,
+    required: true,
+  },
+  duration: {
+    type: Number,
+    required: true,
+  },
+  durationUnit: {
+    type: String, 
+    enum: ["DAYS", "HOURS", "MINUTES","WEEKS","MONTHS"], 
+    required: true,
+  },
+  startDate: {
+    type: Date,
+    default: null,
+  },
+  endDate: {
+    type: Date,
+    default: null,
+  },
+  program: {
+    type: Schema.Types.ObjectId,
+    ref: "ProgramModel",
+  },
+  grading: {
+    type: Schema.Types.ObjectId,
+    ref: "grading",
+  },
+},
+{
+  timestamps: true,
+});
+
+scoreTypeSchema.pre<IScoreType>("save", function (next) {
+  if (this.startDate && this.duration) {
+    const start = new Date(this.startDate);
+    let durationInMilliseconds = 0;
+    if (this.durationUnit === 'DAYS') {
+      durationInMilliseconds = this.duration * 24 * 60 * 60 * 1000;
+    } else if (this.durationUnit === 'HOURS') {
+      durationInMilliseconds = this.duration * 60 * 60 * 1000;
+    } else if (this.durationUnit === 'MINUTES') {
+      durationInMilliseconds = this.duration * 60 * 1000;
+    }else if (this.durationUnit === 'WEEKS') {
+      durationInMilliseconds = this.duration * 7 * 24 * 60 * 60 * 1000;
+    } else if (this.durationUnit === 'MONTHS') {
+      // Approximate months to 30.44 days
+      durationInMilliseconds = this.duration * 30.44 * 24 * 60 * 60 * 1000;
+    }
+     else {
+      throw new Error("Invalid duration unit");
+    }
+
+    this.endDate = new Date(start.getTime() + durationInMilliseconds);
   }
-  )
-);
+  next();
+});
+
+const scoreTypesModel = mongoose.model<IScoreType>("Scores", scoreTypeSchema);
 
 export default scoreTypesModel;

--- a/src/schema/scoreTypesSchema.ts
+++ b/src/schema/scoreTypesSchema.ts
@@ -6,26 +6,29 @@ const Schema = gql`
     title:String!
     description:String!
     modeOfEngagement:String!
-    duration:String!
+    duration: Int!
     startDate:String
     endDate:String
     program:Program
+    grading:Grading
   }
 
   input createScoreType {
     title:String!
     description:String!
     modeOfEngagement:String!
-    duration:String!
+    duration: Int!
     startDate:String
+    durationUnit:String!
     endDate:String
     program:String
+    grading:String
   }
   input updateScoreType {
     title:String
     description:String
     modeOfEngagement:String
-    duration:String
+    duration: Int
     startDate:String
     endDate:String
     program:String
@@ -35,7 +38,7 @@ const Schema = gql`
   }
 
   type Query {
-    getAllScoreTypes(title: String, programId: String): [scoreType]
+    getAllScoreTypes(title: String, programId: String,description:String,modeOfEngagement:String): [scoreType]
     getOneScoreType(id: ID!): scoreType
   }
 


### PR DESCRIPTION
What does this PR do?

- View all/one assessement(s) as superAdmin or admin
- Admin/superAdmin view single assessement
-  Admin/superAdmin update/delete/search of assessement


Description

Both Admin and superAdmin should be able to view/create/delete/update assessements


How should this be tested manually?

Clone this repo and checkout to ft-viewassessement-001 branch

Install all dependencies by running "npm install"

run dev server with "npm run dev" command

Login as admin or superAdmin

Then view all applications

** Any background you want to provide?**

None
Screenshot

None
Questions

None