### PR TITLE
#109 ft implementation role permission update

### DIFF
--- a/src/resolvers/roleResolver.ts
+++ b/src/resolvers/roleResolver.ts
@@ -138,16 +138,28 @@ export const roleResolvers = {
               });
             }
 
-            if (existingPermission) {
-              for (const field of permissionFields) {
-                if (typeof (existingPermission as any)[field] === 'boolean') {
-                  (existingPermission as any)[field] = !(existingPermission as any)[field]; 
-                }
-              }
-              await existingPermission.save();
+            const permissionData: { [key: string]: boolean } = {
+              create: false,
+              viewOwn: false,
+              viewMultiple: false,
+              viewOne: false,
+              updateOwn: false,
+              updateMultiple: false,
+              updateOne: false,
+              deleteOwn: false,
+              deleteMultiple: false,
+              deleteOne: false,
+            };
 
-              existingRole.permissions.push(existingPermission._id);
+            for (const field of permissionFields) {
+              if (field in permissionData) {
+                permissionData[field] = true;
+              }
             }
+
+            Object.assign(existingPermission, permissionData);
+            await existingPermission.save();
+            existingRole.permissions.push(existingPermission._id);
           }
         }
 

--- a/src/schema/roleTypedefs.ts
+++ b/src/schema/roleTypedefs.ts
@@ -3,12 +3,12 @@ import { gql } from 'apollo-server';
 export const roleSchema = gql`
   input PermissionInput {
     entity: String!
-    permissions: [String!]!
+    permissions: [String!]
   }
 
   type Permission {
     entity: String!
-    permissions: [String!]!
+    permissions: [String!]
   }
 
   type Role {


### PR DESCRIPTION
## Description
This PR changes the mutation settings that changed the whole permission array whenever a request  was sent, this made only one permission in the permissions array true and the others false. With this PR that has been adressed by only changing permissions that are in the request header only. This allows unedited permissions to stay false/true until they are changed

## How to test
### Navigate to the directory run the project and use the update rolePermission on Apollo
```
cd atlp-devpulse-bn
git checkout ft-impl-updaterole
npm run dev