### PR TITLE
Fix to avoid multiple user to register with the same phone number

### DIFF
--- a/src/resolvers/loginUserResolver.ts
+++ b/src/resolvers/loginUserResolver.ts
@@ -76,6 +76,12 @@ export const loggedUserResolvers: any = {
       if (existingUser) {
         throw new Error('Email already exists. Please use a different email.');
       }
+      const existingUserByPhone = await LoggedUserModel.findOne({ telephone });
+      if (existingUserByPhone) {
+        throw new Error(
+          "Telephone number already exists. Please use a different number."
+        );
+      }
       const userWithRole = await LoggedUserModel.findById(
         ctx.currentUser?._id,
       ).populate('role');


### PR DESCRIPTION
**PR Description**

This PR fix issue of multiple users from registering with the same phone number. The task was completed but someone make rebase in wrong way and remove this added code to restrict user from registering with the same number.

**Description of tasks that were expected to be completed**

Bug Fix : To prevent multiple users from registering with the same phone number ( ensures each phone number can only be associated with a single user account).
This include add a validation checker that check if  Telephone number already exists or used  in register process by someone else then block he/him to register if number exist and display toast to notify him/her.

**How has this been tested?**

 1. Clone the repository.
 2. Checkout to the fx-phone-number-shared
 3. Run npm install, then npm run dev to verify the app is functioning correctly.
 4. Test the Register first and register at the second time with different details but same phone number then see if it work as expected.

With deployed Link: None

**Track PR (issue number & link)** : #117 

Screenshots (If appropriate especially on the frontend)
N/A
