### PR TITLE
Admin application list seeders

### DIFF
--- a/src/seeders/applicationCyle.ts
+++ b/src/seeders/applicationCyle.ts
@@ -1,0 +1,23 @@
+import { applicationCycle } from '../models/applicationCycle';
+
+const seedApplicationCycle = async () => {
+
+
+	const application = [
+		{
+			name: 'Cycle 1',
+			startDate: '2023-11-15',
+			endDate: '2024-04-01',
+		},
+		{
+			name: 'Cycle 2',
+			startDate: '2024-02-02',
+			endDate: '2024-12-02',
+
+		},
+	];
+	await applicationCycle.deleteMany({application});
+	await applicationCycle.insertMany(application);
+	return null;
+};
+export default seedApplicationCycle;

--- a/src/seeders/applications.ts
+++ b/src/seeders/applications.ts
@@ -1,0 +1,103 @@
+import { applicant_records } from '../models/candidateApplication';
+import { formModel } from '../models/formsModel';
+import { jobModels } from '../models/jobModels';
+import { ProgramModel } from '../models/programModel';
+import { cohortModels } from '../models/cohortModel';
+import { applicationCycle } from '../models/applicationCycle';
+
+const seedApplications = async () => {
+  const program = await ProgramModel.findOne();
+  const cohort = await cohortModels.findOne();
+  const cycle = await applicationCycle.findOne();
+  const jobPostRecords = await jobModels.find();
+
+  if (!program || !cohort || !cycle || jobPostRecords.length < 2) {
+    return;
+  }
+
+  const forms = [
+    {
+      title: 'Software Engineer Application',
+      description: 'Form for applying to Software Engineer position.',
+      jobpost: jobPostRecords[0]._id,
+      link: "https://docs.google.com/forms/d/e/1FAIpQLSezLekXcCODUmxadn2rqNSU_izVpLGLXS7SW02-_tXoq4wgOA/viewform?usp=sf_link",
+      spreadsheetlink: 'https://docs.google.com/spreadsheets/d/1j_97nSDE2LtdLOlkXWAwKlQ0KsO9NMvqenYRRdNPAhQ/edit?usp=sharing',
+    },
+    {
+      title: 'Frontend Developer Application',
+      description: 'Form for applying to Frontend Developer position.',
+      jobpost: jobPostRecords[1]._id,
+      link: "https://docs.google.com/forms/d/e/1FAIpQLSezLekXcCODUmxadn2rqNSU_izVpLGLXS7SW02-_tXoq4wgOA/viewform?usp=sf_link",
+      spreadsheetlink: 'https://docs.google.com/spreadsheets/d/1j_97nSDE2LtdLOlkXWAwKlQ0KsO9NMvqenYRRdNPAhQ/edit?usp=sharing',
+    },
+  ];
+
+  await formModel.deleteMany({});
+  const formRecords = await formModel.insertMany(forms);
+
+  const applicants = [
+    {
+      firstName: 'NGENDAHIMANA',
+      lastName: 'Fidele',
+      email: 'fidnge@msn.com',
+      telephone: '+2507801234569',
+      availability_for_interview: 'Friday, 9:30 - 10:00 PM',
+      gender: 'Male',
+      resume: 'https://example.com/resume/ngendahimana.pdf',
+      comments: 'Looking forward to the interview.',
+      address: '456 KG, Kigali, Rwanda',
+      status: 'submitted',
+      formUrl: formRecords[0].link, 
+      dateOfSubmission: '2024-10-05',
+    },
+    {
+      firstName: 'UWIMANA',
+      lastName: 'Aisha',
+      email: 'uwimana@gmail.com',
+      telephone: '+2507809876543',
+      availability_for_interview: 'Monday, 10:00 - 10:30 AM',
+      gender: 'Female',
+      resume: 'https://example.com/resume/uwimana.pdf',
+      comments: 'I am excited about this opportunity.',
+      address: '789 KG, Kigali, Rwanda',
+      status: 'submitted',
+      formUrl: formRecords[1].link, 
+      dateOfSubmission: '2024-10-06',
+    },
+    {
+      firstName: 'KAMI',
+      lastName: 'David',
+      email: 'davidk@yahoo.com',
+      telephone: '+2507898765432',
+      availability_for_interview: 'Wednesday, 2:00 - 2:30 PM',
+      gender: 'Male',
+      resume: 'https://example.com/resume/kagame.pdf',
+      comments: 'I have experience in full-stack development.',
+      address: '123 KN, Kigali, Rwanda',
+      status: 'submitted',
+      formUrl: formRecords[0].link,
+      dateOfSubmission: '2024-10-07',
+    },
+    {
+      firstName: 'MUKARUGWIZA',
+      lastName: 'Marie',
+      email: 'marie.m@gmail.com',
+      telephone: '+2507823456789',
+      availability_for_interview: 'Thursday, 1:00 - 1:30 PM',
+      gender: 'Female',
+      resume: 'https://example.com/resume/mukarugwiza.pdf',
+      comments: 'Eager to contribute to this project.',
+      address: '234 KG, Kigali, Rwanda',
+      status: 'submitted',
+      formUrl: formRecords[1].link, 
+      dateOfSubmission: '2024-10-08',
+    }
+  ];
+
+  await applicant_records.deleteMany({});
+  await applicant_records.insertMany(applicants);
+
+  console.log('Database seeded successfully');
+};
+
+export default seedApplications;

--- a/src/seeders/index.ts
+++ b/src/seeders/index.ts
@@ -5,12 +5,16 @@ import seedJobs from './jobs';
 import seedPrograms from './programs';
 import seedCohorts from './cohorts';
 import seedUsers from './users';
+import seedApplications from './applications';
+import seedApplicationCycle from './applicationCyle';
 
 connect().then(async () => {
     await seedUsers();
-    await      seedDeleteTrainee()
+    await seedDeleteTrainee()
     await seedPrograms();
+    await seedApplicationCycle();
     await seedCohorts();
     await seedJobs();
+    await seedApplications();
     process.exit()
 })


### PR DESCRIPTION
# Add Seeders for Applicants  Data

### Description:
This PR introduces seeders for populating the database with sample applicant data. The following seeders have been added:

- **Applicant Seeder**: Adds 11 sample applicant records with details like name, email, interview availability, resume links, comments, and submission status. Each applicant is linked to the appropriate form (Software Engineer or Frontend Developer).


### Seeded Data:
- **Applicants**: Eleven sample applicants with unique details are linked to their respective forms.

### Testing Instructions:
To test the seeding functionality and verify that the data is correctly inserted into the database:
1. Ensure your local database is set up.
2. Run the following command to execute the seeders:
   ```bash
   npm run seed

3. After running the command, check the following collections in your database:

   * **Applicants Collection**: Ensure that 4 applicants have been created, each with valid details (name, email, form URL, resume, etc.).

4. Verify that the seeded applicants are associated with the appropriate form records (Software Engineer or Frontend Developer) by checking the `formUrl` field in the applicant documents.

---

### Checklist:

* [x] Added applicant seeders.
* [x] Verified correct linking between applicants and forms.
* [x] Instructions for testing the seeding process provided.


### Screenshot

N/A


