### PR TITLE
implementation of application stages #210

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,8 @@ import { attendanceResolver } from "./resolvers/attendanceResolver";
 import { attendanceSchema } from "./schema/attendanceSchema";
 import { performanceResolver } from "./resolvers/performanceResolver";
 import { performanceSchema } from "./schema/performanceSchema";
-
+import { applicationStageDefs } from './schema/applicationStage';
+import { applicationStageResolvers } from './resolvers/applicationStageResolver';
 import filterJobResolver from "./resolvers/filterJob";
 import filterProgramResolver from "./resolvers/filterPrograms";
 import filterRoleResolver from "./resolvers/filterRole";
@@ -111,7 +112,8 @@ const resolvers = mergeResolvers([
   appliedJobResolver,
   adminNotificationsResolver,
   ticketResolver,
-  filterTicketResolver
+  filterTicketResolver,
+  applicationStageResolvers
 ]);
 const typeDefs = mergeTypeDefs([
   applicationCycleTypeDefs,
@@ -145,7 +147,8 @@ const typeDefs = mergeTypeDefs([
   performanceSchema,
   attendanceSchema,
   adminNotificationsSchema,
-  ticketSchema
+  ticketSchema,
+  applicationStageDefs
 ]);
 
 const server = new ApolloServer({

--- a/src/models/InterviewAssessmentStageSchema.ts
+++ b/src/models/InterviewAssessmentStageSchema.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IInterviewAssessment extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  status: "No action" | "Moved" | "Dismissed";
+  interviewScore: number;
+  comments?: string;
+}
+
+const interviewAssessmentSchema = new Schema<IInterviewAssessment>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Applicant",
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["No action", "Moved", "Dismissed"],
+    default: "No action",
+  },
+  interviewScore: {
+    type: Number,
+    min: 0,
+    max: 2,
+  },
+  comments: {
+    type: String,
+  },
+});
+
+const InterviewAssessment = mongoose.model<IInterviewAssessment>(
+  "InterviewAssessment",
+  interviewAssessmentSchema
+);
+
+export default InterviewAssessment;

--- a/src/models/ShortlistedSchema.ts
+++ b/src/models/ShortlistedSchema.ts
@@ -1,0 +1,26 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IShortlisted extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  status: "No action" | "Moved" | "Dismissed";
+  comments?: string;
+}
+
+const shortlistedSchema = new Schema<IShortlisted>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Applicant",
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["No action", "Moved", "Dismissed"],
+    default: "No action",
+  },
+  comments: {
+    type: String,
+  },
+});
+
+const Shortlisted = mongoose.model<IShortlisted>("Shortlisted", shortlistedSchema);
+export default Shortlisted;

--- a/src/models/admittedStageSchema.ts
+++ b/src/models/admittedStageSchema.ts
@@ -1,0 +1,26 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IAdmitted extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  status: string;
+  interviewScore?: number;
+  comments?: string;
+}
+
+const admittedSchema = new Schema<IAdmitted>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Applicant",
+    required: true,
+  },
+  status: {
+    type: String,
+    required: true,
+  },
+  comments: {
+    type: String,
+  },
+});
+
+const Admitted = mongoose.model<IAdmitted>("Admitted", admittedSchema);
+export default Admitted;

--- a/src/models/dismissedStageSchema.ts
+++ b/src/models/dismissedStageSchema.ts
@@ -1,0 +1,25 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IDismissed extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  stageDismissedFrom: string;
+  comments?: string;
+}
+
+const dismissedSchema = new Schema<IDismissed>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Applicant",
+    required: true,
+  },
+  stageDismissedFrom: {
+    type: String,
+    required: true,
+  },
+  comments: {
+    type: String,
+  },
+});
+
+const Dismissed = mongoose.model<IDismissed>("Dismissed", dismissedSchema);
+export default Dismissed;

--- a/src/models/stageSchema.ts
+++ b/src/models/stageSchema.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IStageTracking extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  currentStage: "Shortlisted" | "Technical Assessment" | "Interview Assessment" | "Admitted" | "Dismissed";
+  history: [
+    {
+      stage: string;
+      enteredAt: Date;
+      exitedAt?: Date;
+    }
+  ];
+}
+
+const stageTrackingSchema = new Schema<IStageTracking>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Trainee",
+    required: true,
+  },
+  currentStage: {
+    type: String,
+    enum: ["Shortlisted", "Technical Assessment", "Interview Assessment", "Admitted", "Dismissed"],
+    required: true,
+  },
+  history: [
+    {
+      stage: { type: String, required: true },
+      enteredAt: { type: Date, default: Date.now },
+      exitedAt: { type: Date },
+    }
+  ]
+});
+
+const StageTracking = mongoose.model<IStageTracking>("StageTracking", stageTrackingSchema);
+export default StageTracking;

--- a/src/models/technicalAssessmentStage.ts
+++ b/src/models/technicalAssessmentStage.ts
@@ -1,0 +1,36 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface ITechnicalAssessment extends Document {
+  applicantId: mongoose.Schema.Types.ObjectId;
+  status: "No action" | "Moved" | "Dismissed";
+  score: number;
+  comments?: string;
+}
+
+const technicalAssessmentSchema = new Schema<ITechnicalAssessment>({
+  applicantId: {
+    type: Schema.Types.ObjectId,
+    ref: "Applicant",
+    required: true,
+  },
+  status: {
+    type: String,
+    enum: ["No action", "Moved", "Dismissed"],
+    default: "No action",
+  },
+  score: {
+    type: Number,
+    min: 0,
+    max: 100,
+  },
+  comments: {
+    type: String,
+  },
+});
+
+const TechnicalAssessment = mongoose.model<ITechnicalAssessment>(
+  "TechnicalAssessment",
+  technicalAssessmentSchema
+);
+
+export default TechnicalAssessment;

--- a/src/models/traineeApplicant.ts
+++ b/src/models/traineeApplicant.ts
@@ -30,12 +30,12 @@ const TraineeApplicant = mongoose.model(
     },
     applicationPhase: {
       type: String,
-      enum: ["Applied", "Interviewed", "Accepted", "Enrolled"],
+      enum: ["Applied", 'Shortlisted', 'Technical Assessment', 'Interview Assessment', 'Admitted', 'Dismissed', "Enrolled"],
       default: "Applied",
     },
     status: {
       type: String,
-      default: "Not Assigned",
+      default: "No action",
     },
     cohort: {
       type: Schema.Types.ObjectId,

--- a/src/resolvers/applicationStageResolver.ts
+++ b/src/resolvers/applicationStageResolver.ts
@@ -1,0 +1,258 @@
+import { CustomGraphQLError } from "../utils/customErrorHandler";
+import TraineeApplicant from "../models/traineeApplicant";
+import StageTracking from "../models/stageSchema";
+import { RoleModel } from "../models/roleModel";
+import Shortlisted from "../models/ShortlistedSchema";
+import Dismissed from "../models/dismissedStageSchema";
+import Admitted from "../models/admittedStageSchema";
+import InterviewAssessment from "../models/InterviewAssessmentStageSchema";
+import TechnicalAssessment from "../models/technicalAssessmentStage";
+
+export const applicationStageResolvers: any = {
+  Query: {
+    getStageHistoryByApplicant: async (_: any, { applicantId }: { applicantId: string }) => {
+      try {
+        const stageTracking = await StageTracking.findOne({ applicantId }).exec();
+        if (!stageTracking) {
+          throw new Error("Applicant not found or has no stage history.");
+        }
+
+        const historyArray = Array.isArray(stageTracking.history) ? stageTracking.history : [];
+
+        return {
+          applicantId: stageTracking.applicantId,
+          currentStage: stageTracking.currentStage,
+          history: historyArray.map((stage) => ({
+            stage: stage.stage,
+            enteredAt: stage.enteredAt.toISOString(),
+            exitedAt: stage.exitedAt ? stage.exitedAt.toISOString() : null,
+          })),
+        };
+      } catch (error:any) {
+        throw new Error(`Failed to retrieve applicant history: ${error.message}`);
+      }
+    },
+    getApplicantsByStage : async (_:any, { stage} : { stage: string}) =>{
+      try {
+        
+        const validStages = ["Shortlisted", "Technical Assessment", "Interview Assessment", "Admitted"];
+        if (!validStages.includes(stage)) {
+          throw new Error("Invalid stage. Please choose a valid stage.");
+        }
+    
+        const applicantsInStage = await StageTracking.find({ currentStage: stage })
+          .populate('applicantId')
+          .exec();
+    
+        return applicantsInStage.map((tracking) => ({
+          applicant: tracking.applicantId,
+          currentStage: tracking.currentStage,
+          history: tracking.history,
+        }));
+      } catch (error:any) {
+        throw new Error(`Failed to retrieve applicants for stage ${stage}: ${error.message}`);
+      }
+    }
+  },
+  Mutation: {
+    moveToNextStage: async (_: any, { applicantId, nextStage, comments }: any,context: any) => {
+      try {
+        if (!context.currentUser) {
+          throw new CustomGraphQLError("You must be logged in to perform this action");
+        }
+    
+        const userRole = await RoleModel.findById({ _id: context.currentUser.role });
+        if (userRole?.roleName !== "admin" && userRole?.roleName !== "superAdmin") {
+          throw new CustomGraphQLError("Only admin and super admins are allowed");
+        }
+    
+        const stageOrder = ["Shortlisted", "Technical Assessment", "Interview Assessment", "Admitted"];
+    
+        let stageTracking = await StageTracking.findOne({ applicantId, exitedAt: { $exists: false } });
+    
+        if (nextStage !== "Dismissed") {
+          const currentStageIndex = stageTracking ? stageOrder.indexOf(stageTracking.currentStage) : -1;
+          const nextStageIndex = stageOrder.indexOf(nextStage);
+    
+          if (nextStageIndex !== currentStageIndex + 1) {
+            return new CustomGraphQLError(`Applicants must proceed through each stage in order. The next stage should be ${stageOrder[currentStageIndex + 1]}.`);
+          }
+        }
+    
+
+        if (stageTracking?.currentStage === nextStage) {
+          return new CustomGraphQLError("The applicant is already in this stage.");
+        }
+    
+        if (nextStage === "Interview Assessment") {
+          const technicalScore = await TechnicalAssessment.findOne({ applicantId });
+          if (!technicalScore || technicalScore.score === undefined || technicalScore.score === null) {
+            return new CustomGraphQLError("Technical assessment score is required before moving to the Interview Assessment, Please add score😎.");
+          }
+        }
+      
+        // If moving to Admitted, ensure Interview Assessment has a score
+        if (nextStage === "Admitted") {
+          const interviewScore = await InterviewAssessment.findOne({ applicantId });
+          if (!interviewScore || interviewScore.interviewScore === undefined || interviewScore.interviewScore === null) {
+            return new CustomGraphQLError("Interview assessment score is required before moving to Admitted, Please add score😎.");
+          }
+        }
+        
+        if (!stageTracking) {
+          stageTracking = new StageTracking({
+            applicantId,
+            currentStage: nextStage,
+            history: [],
+          });
+          await stageTracking.save();
+        } else {
+          stageTracking.history.push({
+            stage: stageTracking.currentStage,
+            enteredAt: stageTracking.history[stageTracking.history.length - 1]?.enteredAt || new Date(),
+            exitedAt: new Date(),
+          });
+    
+          stageTracking.currentStage = nextStage;
+          await stageTracking.save();
+        }
+    
+        
+        let message = "";
+        switch (nextStage) {
+          case "Technical Assessment":
+            if (stageTracking) {
+              await Shortlisted.updateOne(
+                { applicantId, status: "No action" },
+                { $set: { status: "Moved" } }
+              );
+              await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase: nextStage, status: "Moved"}});
+            }
+            
+            await TechnicalAssessment.create({
+              applicantId,
+              comments,
+              status: "No action",
+            });
+            await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase:nextStage, status: "No action"}});
+            message = `Applicant advanced to ${nextStage} stage.`;
+            break;
+    
+          case "Interview Assessment":
+            if (stageTracking) {
+              await TechnicalAssessment.updateOne(
+                { applicantId, status: "No action" },
+                { $set: { status: "Moved" } }
+              );
+              await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase: nextStage, status: "Moved"}});
+            }
+            await InterviewAssessment.create({
+              applicantId,
+              comments,
+              status: "No action",
+            });
+            await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase:nextStage, status: "No action"}});
+            message = `Applicant advanced to ${nextStage} stage.`;
+            break;
+    
+          case "Admitted":
+            if (stageTracking) {
+              await InterviewAssessment.updateOne(
+                { applicantId, status: "No action" },
+                { $set: { status: "Moved" } }
+              );
+            }
+    
+
+            await Admitted.create({
+              applicantId,
+              comments,
+              status: "Passed",
+            });
+            await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase:nextStage, status: "Admitted"}});
+            break;
+    
+          case "Dismissed":
+            if (stageTracking) {
+              await StageTracking.updateOne(
+                { applicantId, currentStage: stageTracking.currentStage },
+                { $set: { status: "Dismissed", exitedAt: new Date() } }
+              );
+            }
+    
+            await Dismissed.create({
+              applicantId,
+              stageDismissedFrom: stageTracking?.currentStage,
+              comments,
+            });
+            await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase:"Dismissed",status: "Dismissed"}});
+            message = `Applicant dismissed from the ${stageTracking.currentStage} stage.`;
+            break;
+    
+          case "Shortlisted":
+            if (stageTracking) {
+              await StageTracking.updateOne(
+                { applicantId, currentStage: stageTracking.currentStage },
+                { $set: { status: "Moved", exitedAt: new Date() } }
+              );
+            }
+    
+            await Shortlisted.create({
+              applicantId,
+              comments,
+              status: "No action",
+            });
+            await TraineeApplicant.updateOne({_id:applicantId},{$set: {applicationPhase:nextStage, status: "No action"}});
+            message = `Applicant advanced to ${nextStage} stage.`;
+            break;
+        }
+    
+        return {
+          success: true,
+          message
+        };
+      } catch (error: any) {
+        return new Error(error.message);
+      }
+    },
+    addScore : async (_:any, {applicantId, applicantStage, score}:{applicantId:string, applicantStage:string, score:number},context:any) =>{
+      try {
+        if (!context.currentUser) {
+          throw new CustomGraphQLError("You must be logged in to perform this action");
+        }
+    
+        const userRole = await RoleModel.findById({ _id: context.currentUser.role });
+        if (userRole?.roleName !== "admin" && userRole?.roleName !== "superAdmin") {
+          throw new CustomGraphQLError("Only admin and super admins are allowed");
+        }
+
+        if (!score){
+          throw new CustomGraphQLError("Score is required");
+        }
+
+        switch (applicantStage) {
+          case "Technical Assessment":
+            await TechnicalAssessment.updateOne(
+              { applicantId, status: "No action" },
+              { $set: { score } }
+            );
+            break;
+          case "Interview Assessment":
+            await InterviewAssessment.updateOne(
+              { applicantId, status: "No action" },
+              { $set: { interviewScore: score } }
+            );
+            break;
+          default:
+            throw new CustomGraphQLError(`Invalid stage. Please choose Technical Assessment or Interview Assessment.`);
+        }
+        return {
+          success: true,
+          message: "Score added successfully"
+        };
+      } catch (error:any) {
+        return new Error(error.message);
+      }
+    }
+  },
+};

--- a/src/schema/applicationStage.ts
+++ b/src/schema/applicationStage.ts
@@ -1,0 +1,52 @@
+import { gql } from "apollo-server-core";
+
+export const applicationStageDefs = gql`
+  type Applicant {
+    _id: ID!
+    email: String
+    firstName: String
+    lastName: String
+    delete_at: Boolean
+    cycle_id: ID
+    applicationPhase: String
+    status: String
+  }
+
+  type Stage {
+    stage: String!
+    enteredAt: String!
+    exitedAt: String
+  }
+  type HistoryStage {
+    applicantId: ID!
+    currentStage: String!
+    history: [Stage!]!
+  }
+  type applicant_records {
+    applicant: Applicant!
+    currentStage: String!
+    history: [Stage!]!
+  }
+
+  type Query {
+    getStageHistoryByApplicant(applicantId: ID!): HistoryStage
+    getApplicantsByStage(stage: String!): [applicant_records!]!
+  }
+
+  type response {
+    success: Boolean!
+    message: String
+  }
+
+  type Mutation {
+    moveToNextStage(
+      applicantId: ID!
+      nextStage: String!
+      comments: String
+    ): response!
+
+    addScore(applicantId:ID!
+    applicantStage:String!
+    score: Float!): response!
+  }
+`;

--- a/src/schema/traineeApplicantSchema.ts
+++ b/src/schema/traineeApplicantSchema.ts
@@ -30,7 +30,7 @@ export const typeDefsTrainee = gql`
     cycle_id: applicationCycle
     delete_at: Boolean
     status: String!
-    applicationPhase: ApplicationPhase!
+    applicationPhase: String!
     cohort: ID
   }
 
@@ -41,8 +41,11 @@ export const typeDefsTrainee = gql`
 
   enum ApplicationPhase {
     Applied
-    Interviewed
-    Accepted
+    Shortlisted
+    Technical_Assessment
+    Interview_Assessment
+    Admitted
+    Dismissed
     Enrolled
   }
 


### PR DESCRIPTION
### PR Description

As an admin, I want to be able to create application stages in an application cycle.
The possible stages are:

- Shortlisted
- Technical assessment
- Interview assessment
- Admitted

### Description of tasks that were expected to be completed

- Move Applicant to the next stage of application
- Applicant can't be on two stages at the same time
- Can't move applicant twice on the same stage
- History of a previous stage
- Comments on each stage
- Score for Technical Assessment and Interview assessment stage needed

### How has this been tested?
Checkout to our branch `ft-application-stage`
Install dependencies: ``npm install`
Run the app: `npm run dev`
Log in as an ` admin` or `superAdmin` and you will be redirected to dashboard page

### Track PR (issue number & link)
The issue link click [here](https://github.com/atlp-rwanda/atlp-devpulse-fn/issues/210l)

### Preview Link
**N/A**

### Credentials
email: [admin@example.com](mailto:admin@example.com)
password: `password123`

Screenshots (If appropriate especially on the frontend)
**N/A**