### PR TITLE
fix(#156): Have a user be able to apply as a trainee

### DIFF
--- a/src/models/traineeApplicant.ts
+++ b/src/models/traineeApplicant.ts
@@ -1,7 +1,14 @@
-import mongoose, { model, Schema } from "mongoose";
-const TraineeApplicant = mongoose.model(
-  "Trainee",
-  new Schema({
+import mongoose, { Schema } from "mongoose";
+
+const CycleAppliedSchema = new Schema({
+  cycle: {
+    type: Schema.Types.ObjectId,
+    ref: 'ApplicationCycle',
+    required: true
+  },
+})
+
+const TraineeApplicantSchema = new Schema({
     user: {
       type: Schema.Types.ObjectId,
       ref: 'User'
@@ -19,15 +26,16 @@ const TraineeApplicant = mongoose.model(
       type: String,
       required: true,
     },
+    cycle_id:{
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "applicationCycle",
+      required: true
+    },
     delete_at: {
       type: Boolean,
       default: false,
     },
-    cycle_id: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "applicationCycle",
-      required: true,
-    },
+    cycleApplied: [CycleAppliedSchema],
     applicationPhase: {
       type: String,
       enum: ["Applied", "Interviewed", "Accepted", "Enrolled"],
@@ -41,7 +49,8 @@ const TraineeApplicant = mongoose.model(
       type: Schema.Types.ObjectId,
       ref: "cohortModel",
     }
-  })
-);
+  });
 
-export default TraineeApplicant;
+const TraineeApplicant = mongoose.model('Trainees', TraineeApplicantSchema);
+
+  export default TraineeApplicant;

--- a/src/models/traineeAttribute.ts
+++ b/src/models/traineeAttribute.ts
@@ -1,124 +1,98 @@
-import mongoose, { model, Schema, Document } from "mongoose";
+import mongoose, { model, Schema } from "mongoose";
 
-interface ITraineeAttribute extends Document {
-  gender?: 'male' | 'female' | 'other';
-  birth_date?: Date;
-  address?: string;
-  phone?: string;
-  study?: boolean;
-  education_level?: 'high school' | 'university' | 'masters' | 'phd';
-  currentEducationLevel?: 'highschool' | 'university' | 'masters' | 'phd';
-  nationality: string;
-  province?: string;
-  district?: string;
-  sector?: string;
-  isEmployed?: boolean;
-  haveLaptop?: boolean;
-  isStudent?: boolean;
-  Hackerrank_score?: string;
-  english_score?: string;
-  interview?: number;
-  interview_decision?: string;
-  applicationPost?: 'Andela Twitter Handle' | 'Got an email from Andela' | 'Referred by a friend' | 'Other';
-  otherApplication?: string;
-  andelaPrograms?: 'Web Development Crash Course' | 'Andela Learning Community' | 'Other';
-  otherPrograms?: string;
-  understandTraining?: boolean;
-  discipline?: string;
-  trainee_id: mongoose.Types.ObjectId;
-}
-
-const traineeAttributeSchema = new Schema<ITraineeAttribute>({
+const traineeAttributeSchema = new Schema({
   gender: {
     type: String,
-    enum: ['male', 'female', 'other'],
+    required: true,
+    default: "-",
   },
   birth_date: {
     type: Date,
+    required: true,
+    default: "01/01/2000",
   },
-  address: {
+  Address: {
     type: String,
+    required: true,
+    default: "-",
   },
   phone: {
     type: String,
+    required: true,
+    default: "-",
   },
-  study: {
-    type: Boolean,
+  field_of_study: {
+    type: String,
+    required: true,
+    default: "-",
   },
   education_level: {
     type: String,
-    enum: ['high school', 'university', 'masters', 'phd'],
-  },
-  currentEducationLevel: {
-    type: String,
-    enum: ['highschool', 'university', 'masters', 'phd'],
-  },
-  nationality: {
-    type: String,
+    required: true,
+    default: "-",
   },
   province: {
     type: String,
+    required: true,
+    default: "-",
   },
   district: {
     type: String,
+    required: true,
+    default: "-",
   },
   sector: {
     type: String,
+    required: true,
+    default: "-",
   },
   isEmployed: {
     type: Boolean,
+    required: true,
+    default: true,
   },
   haveLaptop: {
     type: Boolean,
+    required: true,
+    default: true,
   },
   isStudent: {
     type: Boolean,
+    required: true,
+    default: true,
   },
   Hackerrank_score: {
     type: String,
+    required: true,
+    default: "-",
   },
   english_score: {
     type: String,
+    required: true,
+    default: "-",
   },
   interview: {
     type: Number,
   },
   interview_decision: {
     type: String,
+    required: true,
+    default: "-",
   },
-  applicationPost: {
+  past_andela_programs: {
     type: String,
-    enum: ['Andela Twitter Handle', 'Got an email from Andela', 'Referred by a friend', 'Other'],
-  },
-  otherApplication: {
-    type: String,
-    required: function(this: ITraineeAttribute) {
-      return this.applicationPost === 'Other';
-    },
-  },
-  andelaPrograms: { 
-    type: String,
-    enum: ['Web Development Crash Course', 'Andela Learning Community', 'Other'],
-  },
-  otherPrograms: {
-    type: String,
-    required: function(this: ITraineeAttribute) {
-      return this.andelaPrograms === 'Other';
-    },
+    default: "none",
   },
   understandTraining: {
     type: Boolean,
   },
-  discipline: {
-    type: String,
-  },
   trainee_id: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: "Trainee",
+    ref: "Trainees",
     required: true,
   },
 });
 
-const traineEAttributes = model<ITraineeAttribute>("Attributes", traineeAttributeSchema);
+const traineEAttributes = model("Attributes", traineeAttributeSchema);
 
-export { traineEAttributes, ITraineeAttribute };
+export { traineEAttributes };

--- a/src/resolvers/loginUserResolver.ts
+++ b/src/resolvers/loginUserResolver.ts
@@ -54,6 +54,17 @@ export const loggedUserResolvers: any = {
       const role = await RoleModel.findOne({ _id: user?.role });
       return role;
     },
+    currentUser: async (_: unknown, __: unknown, context: any) => {
+      if (!context.currentUser) {
+        return null;  
+      }
+
+      return {
+        firstName: context.currentUser.firstname, 
+        lastName: context.currentUser.lastname, 
+        email: context.currentUser.email
+      };
+    },
     getByFilter: async (_: any, { filter }: { filter: any }) => {
       const filterQuery: any = {};
       for (const key in filter) {

--- a/src/resolvers/traineeApplicantResolver.ts
+++ b/src/resolvers/traineeApplicantResolver.ts
@@ -1,14 +1,15 @@
 import TraineeApplicant from "../models/traineeApplicant";
 import { traineEAttributes } from "../models/traineeAttribute";
-import { applicationCycle } from "../models/applicationCycle";
+import  {applicationCycle}  from "../models/applicationCycle";
 import mongoose, { ObjectId } from "mongoose";
 import { sendEmailTemplate } from "../helpers/bulkyMails";
+import { Types } from 'mongoose';
 
 const FrontendUrl = process.env.FRONTEND_URL || ""
 
 import { CustomGraphQLError } from "../utils/customErrorHandler";
 import { cohortModels } from "../models/cohortModel";
-import { publishNotification } from "./adminNotificationsResolver";
+import { any } from "joi";
 
 export const traineeApplicantResolver: any = {
   Query: {
@@ -115,8 +116,8 @@ export const traineeApplicantResolver: any = {
         return false;
       }
     },
-    async createNewTraineeApplicant(parent: any, args: any, context: any) {
-      const { lastName, firstName, email, cycle_id, attributes } = args.input;
+    async createNewTraineeApplicant(_:any, { input }:any) {
+      const { lastName, firstName, email, cycle_id, attributes } = input;
     
       // Validate email
       const validateEmail = (email: string) => {
@@ -131,30 +132,46 @@ export const traineeApplicantResolver: any = {
         throw new Error("This email is not valid. Please provide a valid email.");
       }
     
-      // Check if cycle exists
-      const cycle = await applicationCycle.findById(cycle_id);
-      if (!cycle) {
-        throw new Error("The cycle provided does not exist");
-      }
-    
       const session = await mongoose.startSession();
       session.startTransaction();
-    
+
       try {
-        
-        const newTrainee = await TraineeApplicant.create([{
+        const cycle = await applicationCycle.findById(cycle_id).session(session);
+        if (!cycle) {
+          throw new Error("Application cycle not found");
+        }
+
+        const existingTrainee = await TraineeApplicant.findOne({ email }).session(session);
+        if (existingTrainee) {
+          const existingApplication = existingTrainee.cycleApplied.find(
+           ( app: any) => app.cycle.toString() === cycle_id
+          );
+          if (existingApplication) {
+            throw new Error("You have already applied to this application cycle");
+          }
+
+          existingTrainee.cycle_id = cycle_id;
+          existingTrainee.cycleApplied.push({
+            cycle: cycle_id,
+          });
+          await existingTrainee.save({ session });
+          await session.commitTransaction();
+          return existingTrainee;
+        }
+
+        const newTrainee = new TraineeApplicant({
           lastName,
           firstName,
           email,
-          cycle_id
-        }], { session });
-    
+          cycle_id,
+          cycleApplied: [{
+            cycle: cycle_id,
+          }]
+        });
+
+        await newTrainee.save({ session });
         await session.commitTransaction();
-        await publishNotification(
-          `${firstName} ${lastName} has registered as a new Trainee.`,
-          "new_Trainee_application"
-        );
-        return (await newTrainee[0].populate("cycle_id")).toObject();
+        return newTrainee;
       } catch (error) {
         await session.abortTransaction();
         throw error;

--- a/src/resolvers/traineeApplicantResolver.ts
+++ b/src/resolvers/traineeApplicantResolver.ts
@@ -9,6 +9,7 @@ const FrontendUrl = process.env.FRONTEND_URL || ""
 
 import { CustomGraphQLError } from "../utils/customErrorHandler";
 import { cohortModels } from "../models/cohortModel";
+import { publishNotification } from "./adminNotificationsResolver";
 import { any } from "joi";
 
 export const traineeApplicantResolver: any = {
@@ -171,6 +172,10 @@ export const traineeApplicantResolver: any = {
 
         await newTrainee.save({ session });
         await session.commitTransaction();
+        await publishNotification(
+          `${firstName} ${lastName} has registered as a new Trainee.`,
+          "new_Trainee_application"
+        );
         return newTrainee;
       } catch (error) {
         await session.abortTransaction();

--- a/src/resolvers/traineeAttributeResolver.ts
+++ b/src/resolvers/traineeAttributeResolver.ts
@@ -4,15 +4,27 @@ import TraineeApplicant from "../models/traineeApplicant";
 export const traineeAttributeResolver: any = {
   Query: {
     async allTraineesDetails(_: any, { input }: any) {
+      // define page
       const { page, itemsPerPage, All } = input;
-      let pages = page || 1;
-      let items = itemsPerPage || 3;
-
+      let pages;
+      let items;
+      if (page) {
+        pages = page;
+      } else {
+        pages = 1;
+      }
       if (All) {
+        // count total items inside the Attributes
         const totalItems = await traineEAttributes.countDocuments({});
         items = totalItems;
+      } else {
+        if (itemsPerPage) {
+          items = itemsPerPage;
+        } else {
+          items = 3;
+        }
       }
-
+      // define items per page
       const itemsToSkip = (pages - 1) * items;
       const allTraineeAttribute = await traineEAttributes
         .find({})
@@ -91,22 +103,19 @@ export const traineeAttributeResolver: any = {
       }
     },
 
-    async updateTraineeAttribute(_: any, args: any) {
+    async updateTraineeAttribute(parent: any, args: any, context: any) {
       const { ID, attributeUpdateInput } = args;
 
-      if (attributeUpdateInput.birth_date) {
-        attributeUpdateInput.birth_date = new Date(attributeUpdateInput.birth_date);
-      }
-
+      // const updated = await traineEAttributes.findByIdAndUpdate(
       const updated = await traineEAttributes.findOneAndUpdate(
         { trainee_id: ID },
         {
           gender: attributeUpdateInput.gender,
           birth_date: attributeUpdateInput.birth_date,
-          address: attributeUpdateInput.address,
+          Address: attributeUpdateInput.Address,
           phone: attributeUpdateInput.phone,
+          field_of_study: attributeUpdateInput.field_of_study,
           education_level: attributeUpdateInput.education_level,
-          currentEducationLevel: attributeUpdateInput.currentEducationLevel,
           province: attributeUpdateInput.province,
           district: attributeUpdateInput.district,
           sector: attributeUpdateInput.sector,
@@ -117,18 +126,13 @@ export const traineeAttributeResolver: any = {
           english_score: attributeUpdateInput.english_score,
           interview_decision: attributeUpdateInput.interview_decision,
           past_andela_programs: attributeUpdateInput.past_andela_programs,
-          applicationPost: attributeUpdateInput.applicationPost,
-          otherApplication: attributeUpdateInput.otherApplication,
-          andelaPrograms: attributeUpdateInput.andelaPrograms,
-          otherPrograms: attributeUpdateInput.otherPrograms,
-          understandTraining: attributeUpdateInput.understandTraining,
-          discipline: attributeUpdateInput.discipline,
         },
         { new: true }
       );
       if (!updated)
-        throw new Error("No Trainee is found, please provide the correct trainee_id");
-
+        throw new Error(
+          "No Trainee is found, please provide the correct trainee_id"
+        );
       return updated;
     },
   },

--- a/src/schema/loggedUser.ts
+++ b/src/schema/loggedUser.ts
@@ -41,6 +41,12 @@ export const LoggedUserSchema = gql`
 		trainees:[User_Logged!]
   }
 
+  type CurrentUser{
+    firstName: String!
+    lastName: String!
+    email: String!
+  }
+
 
   input UserInput_Logged {
     firstname: String
@@ -95,6 +101,7 @@ export const LoggedUserSchema = gql`
     getByFilter(filter: UserFilterInput!): [User_Logged]!
     getCohort(id: ID!): cohort
 		getAllCohorts: [cohort!]!
+    currentUser: CurrentUser
   }
 
   type Mutation {

--- a/src/schema/traineeApplicantSchema.ts
+++ b/src/schema/traineeApplicantSchema.ts
@@ -1,16 +1,19 @@
 import { gql } from "apollo-server";
+
 export const typeDefsTrainee = gql`
   type Query {
     allTrainees(input: pagination): response
     getOneTrainee(ID: ID!): traineeApplicant
     getTraineeByUserId(userId: ID!): ID!
   }
+
   type response {
     totalItems: Int!
     page: Int!
     itemsPerPage: Int!
     data: [traineeApplicant]!
   }
+
   type Mutation {
     createNewTraineeApplicant(
       input: newTraineeApplicantInput
@@ -22,17 +25,36 @@ export const typeDefsTrainee = gql`
     deleteTraineeApplicant(email: String!): Boolean
     acceptTrainee(traineeId: ID!, cohortId: ID!): AcceptTraineeResponse!
   }
+
   type traineeApplicant {
     lastName: String!
     firstName: String!
     _id: ID!
     email: String!
     cycle_id: applicationCycle
+    cycleApplied: [CycleApplied!]!
     delete_at: Boolean
     status: String!
     applicationPhase: ApplicationPhase!
     cohort: ID
+    user: User
   }
+
+  type CycleApplied {
+    _id: ID!
+    cycle: ApplicationCycle!
+  }
+
+  type User {
+    _id: ID!
+  }
+
+  type applicationCycle {
+  _id: ID!
+  name: String!
+  startDate: String!
+  endDate: String!
+}
 
   type AcceptTraineeResponse {
     success: Boolean!
@@ -47,12 +69,12 @@ export const typeDefsTrainee = gql`
   }
 
   input newTraineeApplicantInput {
-  lastName: String!
-  firstName: String!
-  email: String!
-  cycle_id: String!
-  attributes: TraineeAttributeInput
-}
+    lastName: String!
+    firstName: String!
+    email: String!
+    cycle_id: ID!
+    attributes: traineeAttributeInput
+  }
 
   input traineeApplicantEmail {
     email: String!
@@ -61,7 +83,7 @@ export const typeDefsTrainee = gql`
   input traineeApplicantInputUpdate {
     firstName: String
     lastName: String
-    cycle_id: String!
+    cycle_id: ID
     status: String
   }
 

--- a/src/schema/traineeAttributeSchema.ts
+++ b/src/schema/traineeAttributeSchema.ts
@@ -1,68 +1,55 @@
-import { gql } from "apollo-server";
 
+import { gql } from "apollo-server";
 export const typeDefsAttribute = gql`
   type Query {
-    allTraineesDetails(input: Pagination): [TraineeAttribute]
-    getOneTraineeAllDetails(input: One): TraineeAttribute
+    allTraineesDetails(input: pagination): [traineeAttribute]
+    getOneTraineeAllDetails(input: one): traineeAttribute
   }
-
   type Mutation {
     createTraineeAttribute(
-      attributeInput: TraineeAttributeInput
-    ): TraineeAttributeCreated
+      attributeInput: traineeAttributeInput
+    ): traineeAttributeCreated
     updateTraineeAttribute(
       ID: ID!
-      attributeUpdateInput: TraineeUpdateAttributeInput
-    ): TraineeAttributeCreated
+      attributeUpdateInput: traineeUpdateAttributeInput
+    ): traineeAttributeCreated
   }
-
-  input One {
+  input one {
     id: ID!
   }
-
-  input TraineeAttributeInput {
-    gender: String
-    birth_date: String
-    address: String
-    phone: String
-    study: Boolean
-    education_level: String
-    currentEducationLevel: String
-    nationality: String
-    province: String
-    district: String
-    sector: String
-    isEmployed: Boolean
-    haveLaptop: Boolean
-    isStudent: Boolean
+  input traineeAttributeInput {
+    gender: String!
+    birth_date: String!
+    Address: String!
+    phone: String!
+    field_of_study: String!
+    education_level: String!
+    province: String!
+    district: String!
+    sector: String!
+    isEmployed: Boolean!
+    haveLaptop: Boolean!
+    isStudent: Boolean!
     Hackerrank_score: String
     english_score: String
-    interview: Int
     interview_decision: String
-    applicationPost: String
-    otherApplication: String
-    andelaPrograms: String
-    otherPrograms: String
+    past_andela_programs: String!
     understandTraining: Boolean
-    discipline: String
-    trainee_id: ID!
+    trainee_id: String!
   }
-
-  input Pagination {
+  input pagination {
     page: Int!
     itemsPerPage: Int
     All: Boolean
   }
 
-  input TraineeUpdateAttributeInput {
+  input traineeUpdateAttributeInput {
     gender: String
     birth_date: String
-    address: String
+    Address: String
     phone: String
-    study: Boolean
+    field_of_study: String
     education_level: String
-    currentEducationLevel: String
-    nationality: String
     province: String
     district: String
     sector: String
@@ -71,74 +58,55 @@ export const typeDefsAttribute = gql`
     isStudent: Boolean
     Hackerrank_score: String
     english_score: String
-    interview: Int
     interview_decision: String
-    applicationPost: String
-    otherApplication: String
-    andelaPrograms: String
-    otherPrograms: String
+    past_andela_programs: String
     understandTraining: Boolean
-    discipline: String
   }
 
-  type TraineeAttribute {
+  type traineeAttribute {
+    gender: String!
+    birth_date: String!
+    Address: String!
+    phone: String!
+    field_of_study: String!
+    education_level: String!
+    province: String!
+    district: String!
+    sector: String!
+    isEmployed: Boolean!
+    haveLaptop: Boolean!
+    isStudent: Boolean!
+    Hackerrank_score: String!
+    english_score: String!
+    interview_decision: String!
+    past_andela_programs: String!
+    understandTraining: Boolean
     _id: ID
-    gender: String
-    birth_date: String
-    address: String
-    phone: String
-    study: Boolean
-    education_level: String
-    currentEducationLevel: String
-    nationality: String
-    province: String
-    district: String
-    sector: String
-    isEmployed: Boolean
-    haveLaptop: Boolean
-    isStudent: Boolean
-    Hackerrank_score: String
-    english_score: String
-    interview: Int
-    interview_decision: String
-    applicationPost: String
-    otherApplication: String
-    andelaPrograms: String
-    otherPrograms: String
-    understandTraining: Boolean
-    discipline: String
-    trainee: TraineeApplicant!
+    trainee_id: traineeApplicant!
   }
 
-  type TraineeAttributeCreated {
+  type traineeAttributeCreated {
+    gender: String!
+    birth_date: String!
+    Address: String!
+    phone: String!
+    field_of_study: String!
+    education_level: String!
+    province: String!
+    district: String!
+    sector: String!
+    isEmployed: Boolean!
+    haveLaptop: Boolean!
+    isStudent: Boolean!
+    Hackerrank_score: String
+    english_score: String
+    interview_decision: String
+    past_andela_programs: String!
+    understandTraining: Boolean
     _id: ID
-    gender: String
-    birth_date: String
-    address: String
-    phone: String
-    study: Boolean
-    education_level: String
-    currentEducationLevel: String
-    nationality: String
-    province: String
-    district: String
-    sector: String
-    discipline: String
-    isEmployed: Boolean
-    haveLaptop: Boolean
-    isStudent: Boolean
-    Hackerrank_score: String
-    english_score: String
-    interview: Int
-    interview_decision: String
-    applicationPost: String
-    otherApplication: String
-    andelaPrograms: String
-    otherPrograms: String
-    understandTraining: Boolean
-    trainee_id: ID!
+    trainee_id: String!
   }
-
+  
   type TraineeApplicant {
     _id: ID!
     lastName: String!


### PR DESCRIPTION
PR Description
This PR is for working on the requested changes on the ft-trainee-application on the frontend.

Description of tasks that were expected to be completed
A user has to be able to apply for becoming a trainee , but the the first name, last name and email must be those of the logged in user.

Functionality
After logging in navigate to my applicaiton, then click on Become a trainee button, and fill the form. After successfully submitting the application, you will be prompted to fill the rest of the information so that your application can be considered.

How has this been tested?
This was tested using apollo server
On the Preview link you can login as superAdmin
email: [admin@example.com](mailto:admin@example.com)
password: password123

Track PR
https://github.com/atlp-rwanda/atlp-devpulse-fn/issues/156

Screenshots (If appropriate)

N/A