### PR TITLE
fix:admin assign a cohort to a trainee

### DIFF
--- a/src/models/cohortModel.ts
+++ b/src/models/cohortModel.ts
@@ -30,7 +30,7 @@ export const cohortModels = mongoose.model('cohortModel',
         },
         trainees: [{
             type: Schema.Types.ObjectId,
-            ref: "Trainee",
+            ref: "Trainees",
         }]
     })
 )

--- a/src/models/cohortModel.ts
+++ b/src/models/cohortModel.ts
@@ -17,8 +17,9 @@ export const cohortModels = mongoose.model('cohortModel',
             required: true 
         },
         phase:{
-            type:Number,
-            default: 1
+            type:String,
+            enum: ["Core Concept", "Team Project", "Apprenticeship"],
+            default: "Core Concept",
         },
         start:{
             type:String,

--- a/src/resolvers/cohortResolver.ts
+++ b/src/resolvers/cohortResolver.ts
@@ -8,7 +8,7 @@ export const cohortResolver =  {
         getAllCohorts: async (_: any, args: any, context: any) => {
 
 			try {
-				const cohorts = await cohortModels.find();
+				const cohorts = await cohortModels.find().populate("trainees program cycle");
 				if (cohorts.length === 0) {
 					throw new CustomGraphQLError("no jobpost found");
 				}
@@ -20,7 +20,7 @@ export const cohortResolver =  {
         getCohort: async (_: any, args: any, context: any) => {
 			
 			try {
-				const cohort = await cohortModels.findOne({ _id: args.id });
+				const cohort = await cohortModels.findOne({ _id: args.id }).populate("trainees program cycle");
 				if (!cohort) {
 					throw new Error("no cohort found");
 				}

--- a/src/resolvers/cohortResolver.ts
+++ b/src/resolvers/cohortResolver.ts
@@ -64,5 +64,84 @@ export const cohortResolver =  {
 				throw new CustomGraphQLError(`Something went wrong: ${error}`);
 			}
 		},
+		updateCohort: async (_: any, { id, cohortFields }: any, context: any) => {
+            const userWithRole = await LoggedUserModel.findById(
+                context.currentUser?._id
+            ).populate("role");
+            
+            if (
+                !userWithRole ||
+                ((userWithRole.role as any)?.roleName !== "admin" &&
+                    (userWithRole.role as any)?.roleName !== "superAdmin")
+            ) {
+                throw new CustomGraphQLError(
+                    "You do not have permission to perform this action"
+                );
+            }
+
+            try {
+                const existingCohort = await cohortModels.findById(id);
+                if (!existingCohort) {
+                    throw new CustomGraphQLError("Cohort not found");
+                }
+
+                const existingRecord = await cohortModels.findOne({ title: cohortFields.title });
+
+				if (existingRecord) {
+					throw new CustomGraphQLError(
+						`the cohort with same title exist`
+					);
+				}
+
+                const updatedCohort = await cohortModels.findByIdAndUpdate(
+                    id,
+                    { $set: cohortFields },
+                    { new: true, runValidators: true }
+                ).populate("trainees program cycle");
+
+                if (!updatedCohort) {
+                    throw new CustomGraphQLError("Failed to update cohort");
+                }
+
+                await publishNotification(
+                    `Cohort ${updatedCohort.title} has been updated`,
+                    "Cohort Update"
+                );
+                return updatedCohort;
+            } catch (error) {
+                throw new CustomGraphQLError(`Failed to update cohort: ${error}`);
+            }
+		},
+			deleteCohort: async (_: any, args: any, context: any) => {
+            const userWithRole = await LoggedUserModel.findById(
+                context.currentUser?._id
+            ).populate("role");
+            
+            if (
+                !userWithRole ||
+                ((userWithRole.role as any)?.roleName !== "admin" &&
+                    (userWithRole.role as any)?.roleName !== "superAdmin")
+            ) {
+                throw new CustomGraphQLError(
+                    "You do not have permission to perform this action"
+                );
+            }
+
+            try {
+                const deletedCohort = await cohortModels.findByIdAndDelete(args.id);
+                if (!deletedCohort) {
+                    throw new CustomGraphQLError("Cohort not found");
+                }
+
+                await publishNotification(
+                    `Cohort has been deleted`,
+                    "Cohort Deletion"
+                );
+				const message = `Cohort has been deleted successfully`;
+                return message;
+            } catch (error) {
+                throw new CustomGraphQLError(`Failed to delete cohort: ${error}`);
+            }
+        },
     }
 }

--- a/src/resolvers/cohortResolver.ts
+++ b/src/resolvers/cohortResolver.ts
@@ -64,54 +64,53 @@ export const cohortResolver =  {
 				throw new CustomGraphQLError(`Something went wrong: ${error}`);
 			}
 		},
-		updateCohort: async (_: any, { id, cohortFields }: any, context: any) => {
+        updateCohort: async (_: any, { id, cohortFields }: any, context: any) => {
             const userWithRole = await LoggedUserModel.findById(
-                context.currentUser?._id
+              context.currentUser?._id
             ).populate("role");
-            
+      
             if (
-                !userWithRole ||
-                ((userWithRole.role as any)?.roleName !== "admin" &&
-                    (userWithRole.role as any)?.roleName !== "superAdmin")
+              !userWithRole ||
+              ((userWithRole.role as any)?.roleName !== "admin" &&
+                (userWithRole.role as any)?.roleName !== "superAdmin")
             ) {
-                throw new CustomGraphQLError(
-                    "You do not have permission to perform this action"
-                );
+              throw new CustomGraphQLError(
+                "You do not have permission to perform this action"
+              );
             }
-
             try {
-                const existingCohort = await cohortModels.findById(id);
-                if (!existingCohort) {
-                    throw new CustomGraphQLError("Cohort not found");
+              const existingCohort = await cohortModels.findById(id);
+              if (!existingCohort) {
+                throw new CustomGraphQLError("Cohort not found");
+              }
+      
+              if (cohortFields.title) {
+                const existingRecord = await cohortModels.findOne({
+                  title: cohortFields.title,
+                  _id: { $ne: id },
+                });
+                if (existingRecord) {
+                  throw new CustomGraphQLError("The cohort with same title exists");
                 }
-
-                const existingRecord = await cohortModels.findOne({ title: cohortFields.title });
-
-				if (existingRecord) {
-					throw new CustomGraphQLError(
-						`the cohort with same title exist`
-					);
-				}
-
-                const updatedCohort = await cohortModels.findByIdAndUpdate(
-                    id,
-                    { $set: cohortFields },
-                    { new: true, runValidators: true }
-                ).populate("trainees program cycle");
-
-                if (!updatedCohort) {
-                    throw new CustomGraphQLError("Failed to update cohort");
-                }
-
-                await publishNotification(
-                    `Cohort ${updatedCohort.title} has been updated`,
-                    "Cohort Update"
-                );
-                return updatedCohort;
+              }
+      
+              const updatedCohort = await cohortModels
+                .findByIdAndUpdate(
+                  id,
+                  { $set: cohortFields },
+                  { new: true, runValidators: true }
+                )
+                .populate("trainees program cycle");
+      
+              if (!updatedCohort) {
+                throw new CustomGraphQLError("Failed to update cohort");
+              }
+              return updatedCohort;
             } catch (error) {
-                throw new CustomGraphQLError(`Failed to update cohort: ${error}`);
+              console.error("Update cohort error:", error);
+              throw new CustomGraphQLError(`Failed to update cohort: ${error}`);
             }
-		},
+          },
 			deleteCohort: async (_: any, args: any, context: any) => {
             const userWithRole = await LoggedUserModel.findById(
                 context.currentUser?._id

--- a/src/resolvers/traineeApplicantResolver.ts
+++ b/src/resolvers/traineeApplicantResolver.ts
@@ -4,6 +4,9 @@ import  {applicationCycle}  from "../models/applicationCycle";
 import mongoose, { ObjectId } from "mongoose";
 import { sendEmailTemplate } from "../helpers/bulkyMails";
 import { Types } from 'mongoose';
+import { AuthenticationError } from 'apollo-server';
+import { LoggedUserModel } from "../models/AuthUser";
+import { RoleModel } from "../models/roleModel";
 
 const FrontendUrl = process.env.FRONTEND_URL || ""
 
@@ -11,6 +14,10 @@ import { CustomGraphQLError } from "../utils/customErrorHandler";
 import { cohortModels } from "../models/cohortModel";
 import { publishNotification } from "./adminNotificationsResolver";
 import { any } from "joi";
+
+interface Context {
+  currentUser: { _id: string };
+}
 
 export const traineeApplicantResolver: any = {
   Query: {
@@ -185,15 +192,32 @@ export const traineeApplicantResolver: any = {
       }
     },
 
-    async acceptTrainee(_: any, { traineeId, cohortId }: any){
-      try{
-        const trainee = await TraineeApplicant.findById(traineeId);
-        if(!trainee){
-          throw new CustomGraphQLError("Trainee not found");
-
+    async acceptTrainee(_: any, { traineeId, cohortId }: any, ctx: Context) {
+      try {
+        if (!ctx.currentUser) {
+          throw new AuthenticationError("You must be logged in");
+        }
+        const userWithRole = await LoggedUserModel.findById(
+          ctx.currentUser._id
+        ).populate("role");
+        if (
+          !userWithRole ||
+          ((userWithRole.role as any)?.roleName !== "admin" &&
+            (userWithRole.role as any)?.roleName !== "superAdmin")
+        ) {
+          throw new AuthenticationError("Not allowed to access.");
         }
 
-        const cohort = await cohortModels.findById(cohortId);
+        const trainee = await TraineeApplicant.findById(traineeId);
+        if (!trainee) {
+          throw new CustomGraphQLError("Trainee not found");
+        }
+
+        if (trainee.cohort) {
+          throw new CustomGraphQLError("Trainee already belongs to a cohort");
+        }
+
+        const cohort = await cohortModels.findById(cohortId).populate('trainees');
         if (!cohort) {
           throw new CustomGraphQLError("Cohort not found");
         }

--- a/src/schema/cohortScheme.ts
+++ b/src/schema/cohortScheme.ts
@@ -8,7 +8,7 @@ export const cohortSchema = gql`
 		cycle: applicationCycle
 		start: String
 		end: String
-		phase: Int
+		phase: String
 		trainees:[traineeApplicant]
 		
 	}
@@ -24,18 +24,20 @@ export const cohortSchema = gql`
 		cycle: String!
         start: String!
         end: String!
-		phase: Int
+		phase: String!
   }
+  input updateCohortInput {
+    title: String
+    program: String
+    cycle: String
+    start: String
+    end: String
+    phase: String
+  }
+
 	type Mutation {
 		createCohort(cohortFields: cohortInput): cohort
-		deleteCohort(id: ID!): cohort
-		updateCohort(
-			title: String
-			program: String
-		    cycle: String
-			phase: Int
-            start: String
-            end: String
-		): cohort!
+		deleteCohort(id: ID!): String
+		updateCohort(id: ID!, cohortFields: updateCohortInput): cohort
 	}
 `;

--- a/src/schema/cohortScheme.ts
+++ b/src/schema/cohortScheme.ts
@@ -9,7 +9,7 @@ export const cohortSchema = gql`
 		start: String
 		end: String
 		phase: Int
-		trainees:[ID!]
+		trainees:[traineeApplicant]
 		
 	}
 

--- a/src/seeders/cohorts.ts
+++ b/src/seeders/cohorts.ts
@@ -12,16 +12,16 @@ const seedCohorts = async () => {
     const cohorts = [
         {
             title: "Cohort 1",
-            program: program._id,
-            cycle: cycle._id,
+            program: program,
+            cycle: cycle,
             phase: 1,
             start: "2022-01-01",
             end: "2022-12-31"
         },
         {
             title: "Cohort 2",
-            program: program._id,
-            cycle: cycle._id,
+            program: program,
+            cycle: cycle,
             phase: 2,
             start: "2023-01-01",
             end: "2023-12-31"

--- a/src/seeders/cohorts.ts
+++ b/src/seeders/cohorts.ts
@@ -14,7 +14,7 @@ const seedCohorts = async () => {
             title: "Cohort 1",
             program: program,
             cycle: cycle,
-            phase: 1,
+            phase:"Core Concept",
             start: "2022-01-01",
             end: "2022-12-31"
         },
@@ -22,7 +22,7 @@ const seedCohorts = async () => {
             title: "Cohort 2",
             program: program,
             cycle: cycle,
-            phase: 2,
+            phase:"Core Concept",
             start: "2023-01-01",
             end: "2023-12-31"
         },


### PR DESCRIPTION
### PR Description
This PR is fixing admin should be able to assign a cohort to a trainee.

### Description of tasks that were expected to be completed
- Fixing the feature admin should be able to assign a cohort to a trainee.
- Also added the missing CRUD operations for cohort.

## Functionality
AcceptTrainee Mutation: Assigns a trainee to a cohort by `traineeId` and `cohortId`.

### How has this been tested?
This was tested using apollo server
Checkout to our branch `fx-admin-assign-cohort-to-trainee`
Install dependencies: ``npm install`
Run the app: `npm run dev`

Login in using the mutation called `Login` with the following credentials:
- email: admin@example.com
- password: password123

After that put the token you got in this mutation called `AcceptTrainee` and provide the `traineeId` and `cohortId` then that trainee will assigned into that cohort.


Track PR Issue (NA)

Screenshots (If appropriate)


N/A