### PR TITLE
#250 Add documentation feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,8 @@ import { jobApplicationTypeDefs } from "./schema/jobApplicationSchema";
 import { jobApplicationResolver } from "./resolvers/jobApplicationResolver";
 import { blogRelatedResolvers } from "./resolvers/blogRelatedArticlesResolver";
 import { blogRelatedArticlesSchema } from "./schema/blogRelatedArticlesSchema";
-
+import { DocSchema } from "./schema/doc";
+import { docResolver } from "./resolvers/Doc";
 const PORT = process.env.PORT || 3000;
 
 const resolvers = mergeResolvers([
@@ -135,7 +136,8 @@ const resolvers = mergeResolvers([
   commentResolvers,
   commentLikeResolvers,
   commentReplyResolvers,
-  blogRelatedResolvers
+  blogRelatedResolvers,
+  docResolver
 ]);
 const typeDefs = mergeTypeDefs([
   applicationCycleTypeDefs,
@@ -177,7 +179,8 @@ const typeDefs = mergeTypeDefs([
   commentReplySchema,
   commentLikeSchema,
   jobApplicationTypeDefs,
-  blogRelatedArticlesSchema
+  blogRelatedArticlesSchema,
+  DocSchema
 ]);
 
 const server = new ApolloServer({

--- a/src/models/doc.ts
+++ b/src/models/doc.ts
@@ -1,0 +1,15 @@
+import mongoose, { Schema } from "mongoose";
+
+export const docModels = mongoose.model('docModel',
+    new mongoose.Schema({
+        title:{
+            type:String,
+        },
+        description:{
+            type:String,
+        },
+        role:{
+            type:String
+        }
+    })
+)

--- a/src/resolvers/Doc.ts
+++ b/src/resolvers/Doc.ts
@@ -1,0 +1,47 @@
+import { docModels } from "../models/doc";
+
+export const docResolver:any={
+    Query:{
+        async getDoc(_:any,args:any){
+            const doc=await docModels.findOne({_id:args.id});
+            return doc;
+        },
+        async getAllDocs(){
+            const docs=await docModels.find();
+            return docs;
+        },
+        async getDocByRole(_:any,args:any){
+            const {role}=args;
+            const docs=await docModels.find({role:role})
+            return docs
+        }
+    },
+    Mutation:{
+        async createDoc(_:any,args:any){
+            const {title,description,role}=args.docFields;
+            const doc=await docModels.create({
+                title:title,
+                description:description,
+                role:role
+            });
+            return doc;
+        },
+        async deleteDoc(_:any,args:any){
+            const doc= await docModels.findOneAndDelete({id:args.id})
+            return doc;
+        },
+        async updateDoc(_:any,args:any){
+            const {id}=args;
+            const {title,description,role}=args.docFields
+            let doc=await docModels.findOne({_id:id});
+            if(!doc){
+                return "Document don't exist"
+            }
+            doc.title=title;
+            doc.description=description;
+            doc.role=role
+            await doc?.save()
+            return doc
+        }
+    }
+}

--- a/src/schema/doc.ts
+++ b/src/schema/doc.ts
@@ -1,0 +1,31 @@
+import { gql } from "apollo-server-core";
+
+export const DocSchema = gql`
+  type Doc {
+    id: ID!
+    title: String!
+    description: String!
+    role:String!
+  }
+
+  input createDocVariables {
+    title:String
+    description:String
+    role:String
+  }
+  type Query {
+    getDoc(id: ID!): Doc
+    getAllDocs: [Doc!]!
+    getDocByRole(role:String!):[Doc!]!
+  }
+  input docUpdate {
+    title: String
+    description: String
+    role:String
+  }
+  type Mutation {
+    createDoc(docFields: createDocVariables!): Doc
+    deleteDoc(id: ID!): Doc
+    updateDoc(id: ID!, docFields: docUpdate): Doc
+  }
+`;


### PR DESCRIPTION
### PR Description

This PR allows admin to create, update, view and delete docs. 

### Description of tasks that were expected to be completed

As an applicant I can view the documents on the docs page. 
As an admin I should be able to create, view, update and delete the documents on docs page

### How can this been tested?
- Clone repo
- Checkout branch `ft-documentation-bn`
- Make sure that you set the environment variables referring to `.env.example`
- Run `npm install`, then `npm run dev` to check if the app is running successfully
- Use apolo server and interact with doc resolvers


### Track PR (issue number & link)
Issue: [#250](https://github.com/atlp-rwanda/atlp-devpulse-fn/issues/250)

### Screenshots (If appropriate especially on the frontend)
N/A