### PR TITLE
Integrate related ads with blog content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,8 @@ import { commentLikeResolvers } from "./resolvers/commentLikeResolvers";
 import { commentReplyResolvers } from "./resolvers/commentReplyResolvers";
 import { jobApplicationTypeDefs } from "./schema/jobApplicationSchema";
 import { jobApplicationResolver } from "./resolvers/jobApplicationResolver";
+import { blogRelatedResolvers } from "./resolvers/blogRelatedArticlesResolver";
+import { blogRelatedArticlesSchema } from "./schema/blogRelatedArticlesSchema";
 
 const PORT = process.env.PORT || 3000;
 
@@ -133,6 +135,7 @@ const resolvers = mergeResolvers([
   commentResolvers,
   commentLikeResolvers,
   commentReplyResolvers,
+  blogRelatedResolvers
 ]);
 const typeDefs = mergeTypeDefs([
   applicationCycleTypeDefs,
@@ -174,6 +177,7 @@ const typeDefs = mergeTypeDefs([
   commentReplySchema,
   commentLikeSchema,
   jobApplicationTypeDefs,
+  blogRelatedArticlesSchema
 ]);
 
 const server = new ApolloServer({

--- a/src/resolvers/blogRelatedArticlesResolver.ts
+++ b/src/resolvers/blogRelatedArticlesResolver.ts
@@ -1,0 +1,46 @@
+import axios from "axios";
+import dotenv from 'dotenv';
+import { BlogModel } from "../models/blogModel";
+
+
+dotenv.config();
+interface articleDef {
+  image: string; 
+  title: string; 
+  url: string; 
+  source: { name: string; }; 
+  description: string; 
+  publishedAt: String; 
+}
+export const blogRelatedResolvers = {
+    Query: {
+     blogRelatedArticles: async (_: any,{ blogId }: { blogId: string }) => {
+        try{
+        const blog = await BlogModel.findById(blogId);
+        const tags = blog?.tags;
+
+        if (!tags || tags.length === 0) {
+          throw new Error('Blog tags are missing.');
+        }
+        const keywords = tags[Math.floor(Math.random() * tags.length)];
+        const response = await axios.get('https://gnews.io/api/v4/search', {
+          params: {
+            q: keywords,
+            token: process.env.Gnews_Api_Key,
+            lang: 'en',
+          },});
+        return response.data.articles.map((article:articleDef ) => ({
+          title: article.title,
+          url: article.url,
+          source: article.source.name,
+          description: article.description,
+          image: article.image,
+          publishedAt: article.publishedAt
+        }));
+    } catch (error: any) {
+        throw new Error("Failed to fetch related articles. Please try again later.");
+      }
+      },
+    },
+  };
+  

--- a/src/schema/blogRelatedArticlesSchema.ts
+++ b/src/schema/blogRelatedArticlesSchema.ts
@@ -1,0 +1,17 @@
+import { gql } from "apollo-server-express";
+
+export const blogRelatedArticlesSchema = gql`
+
+type Article  {
+  title: String
+  url: String
+  source: String
+  description: String
+  image: String
+  publishedAt: String
+}
+
+type Query {
+  blogRelatedArticles(blogId: String!): [Article]
+}
+`;


### PR DESCRIPTION
### **PR Title**: Backend Resolver for Blog Ads Integration with GNews API

---

#### **Summary of Changes:**

- Created a GraphQL resolver to integrate blog ads using the **GNews API**.
- The resolver fetches relevant news articles based on blog tags and serves them as ads for blog posts.
- Integrated dynamic ad fetching logic that uses blog tags to query the GNews API.

#### **Details:**

- **New Resolver**: Added `blogAds` resolver to fetch and return ads (news articles) based on the blog's tags.
- **Ad Service**: Integrated **GNews API** to dynamically pull related news articles and use them as ads for blogs.
- **GraphQL Schema**: Added `blogAds` field to the schema to retrieve ads based on blog tags.

#### **Testing:**

- Manually tested the resolver with multiple blogs to ensure relevant news articles are returned as ads.
---

## **Here is output of fetched artcles in apollo server**
<img width="959" alt="related article" src="https://github.com/user-attachments/assets/d2c0ff62-110a-4ef3-88e6-048f8783f62e">
