### PR TITLE
Fix error in Job Application Schema

### DIFF
--- a/src/schema/jobApplicationSchema.ts
+++ b/src/schema/jobApplicationSchema.ts
@@ -18,8 +18,8 @@ export const jobApplicationTypeDefs = gql`
 
     type JobApplication {
         _id: ID!
-        userId: User!
-        jobId: Job!
+        userId: User
+        jobId: Job
         essay: String!
         resume: String!
         status: String!


### PR DESCRIPTION
## What does this PR do?
- This PR fixes an error in the job application schema that was causing job applications not to be returned on admin side.

## How can this be manually tested?
- By attempting to retrieve all job applications on the admin side using the getAllJobApplications query