### PR TITLE
allow trainee to create blog

### DIFF
--- a/src/resolvers/blogResolvers.ts
+++ b/src/resolvers/blogResolvers.ts
@@ -102,12 +102,14 @@ export const blogResolvers = {
         context.currentUser?._id
       ).populate("role");
 
-      if (
-        !userWithRole ||
-        (userWithRole.role as any)?.roleName !== "applicant"
-      ) {
-        throw new CustomGraphQLError("Only Trainness can create blogs");
+      if (!userWithRole) {
+        throw new CustomGraphQLError("User not found or not logged in");
       }
+       const roleName = (userWithRole.role as any)?.roleName;
+
+       if (!["applicant", "trainee"].includes(roleName)) {
+         throw new CustomGraphQLError("Only Trainness can create blogs");
+       }
       try {
         const existingRecord = await BlogModel.findOne({
           title: args.blogFields.title,


### PR DESCRIPTION
### PR Description

This fix allow trainee to create a blog

### Description of tasks that were expected to be completed

As applicant after Passed all phase and became trainee also can be allowed to create blogs, so this  fix allow trainee to be able to create blog

### How has this been tested?
- Clone repo
- Checkout branch `fx-allow-trainee-to-create-blog`
- Make sure that you set the environment variables referring to `.env.example`
- Run `npm install`, then `npm run dev` to check if the app is running successfully
- Apply as applicant then follow steps from first phase until you are accepted after complete all phase(shortlisted,technical,interview then admitted) now you will assigned new role as trainee, then login with trainee credentail navigate to blog then create blog



