### PR TITLE
Admin should be able to hide a blog

### DIFF
--- a/src/resolvers/blogResolvers.ts
+++ b/src/resolvers/blogResolvers.ts
@@ -58,38 +58,36 @@ export const blogResolvers = {
         tag: { type: GraphQLString },
       },
       resolve: async (_: any, { tag }: GetAllBlogsArgs, context: any) => {
-
         try {
-          const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
-  
-          if (!userWithRole) {
-            throw new CustomGraphQLError("User not found or not authenticated.");
-          }
-  
+          const userWithRole = context.currentUser
+            ? await LoggedUserModel.findById(context.currentUser._id).populate("role")
+            : null;
+
           const filter = tag ? { tags: tag } : {};
-  
           const blogs = await BlogModel.find(filter).populate("author likes comments");
-  
+
           return blogs.filter((blog) => {
             if (blog.isHidden) {
-              const authorId = blog.author._id;
-              const currentUserId = context.currentUser?._id;
+              if (userWithRole) {
+                const authorId = blog.author._id;
+                const currentUserId = context.currentUser._id;
 
-              const isSameUser = new mongoose.Types.ObjectId(authorId).equals(new mongoose.Types.ObjectId(currentUserId));
+                const isSameUser = new mongoose.Types.ObjectId(authorId).equals(new mongoose.Types.ObjectId(currentUserId));
+                const isAdmin = ["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName);
 
-              if (isSameUser || 
-                  ["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
-                return true; 
+                // Show hidden blog if the user is the author or has an admins role
+                return isSameUser || isAdmin;
               }
-              return false; 
+              return false;
             }
-            return true; 
+            return true;
           });
         } catch (error: any) {
           throw new CustomGraphQLError(`Error fetching blogs: ${error.message}`);
         }
       },
     },
+
 
     getBlogsByAuthor: {
       type: new GraphQLList(BlogType),
@@ -192,8 +190,8 @@ export const blogResolvers = {
 
       const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
 
-      if (!userWithRole || 
-          !["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
+      if (!userWithRole ||
+        !["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
         throw new CustomGraphQLError("You do not have permission to hide this blog.");
       }
       const blogId = new mongoose.Types.ObjectId(id);

--- a/src/resolvers/blogResolvers.ts
+++ b/src/resolvers/blogResolvers.ts
@@ -1,4 +1,5 @@
 import { BlogModel } from "../models/blogModel";
+import mongoose from "mongoose";
 
 import {
   GraphQLBoolean,
@@ -45,6 +46,10 @@ interface DeleteBlogArgs {
   id: string;
 }
 
+interface HideBlogArgs {
+  id: string;
+}
+
 export const blogResolvers = {
   Query: {
     getAllBlogs: {
@@ -52,9 +57,37 @@ export const blogResolvers = {
       args: {
         tag: { type: GraphQLString },
       },
-      resolve: async (_: any, { tag }: GetAllBlogsArgs) => {
-        const filter = tag ? { tags: tag } : {};
-        return BlogModel.find(filter).populate("author likes comments");
+      resolve: async (_: any, { tag }: GetAllBlogsArgs, context: any) => {
+
+        try {
+          const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
+  
+          if (!userWithRole) {
+            throw new CustomGraphQLError("User not found or not authenticated.");
+          }
+  
+          const filter = tag ? { tags: tag } : {};
+  
+          const blogs = await BlogModel.find(filter).populate("author likes comments");
+  
+          return blogs.filter((blog) => {
+            if (blog.isHidden) {
+              const authorId = blog.author._id;
+              const currentUserId = context.currentUser?._id;
+
+              const isSameUser = new mongoose.Types.ObjectId(authorId).equals(new mongoose.Types.ObjectId(currentUserId));
+
+              if (isSameUser || 
+                  ["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
+                return true; 
+              }
+              return false; 
+            }
+            return true; 
+          });
+        } catch (error: any) {
+          throw new CustomGraphQLError(`Error fetching blogs: ${error.message}`);
+        }
       },
     },
 
@@ -153,6 +186,28 @@ export const blogResolvers = {
         await BlogModel.findByIdAndDelete(id);
         return "Blog deleted successfully";
       },
+    },
+
+    hideBlog: async (_: any, { id }: HideBlogArgs, context: any) => {
+
+      const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
+
+      if (!userWithRole || 
+          !["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
+        throw new CustomGraphQLError("You do not have permission to hide this blog.");
+      }
+      const blogId = new mongoose.Types.ObjectId(id);
+
+      const blog = await BlogModel.findById(blogId);
+      if (!blog) {
+        throw new CustomGraphQLError("Blog not found.");
+      }
+
+      blog.isHidden = !blog.isHidden;
+
+      await blog.save();
+
+      return blog;
     },
   },
 };

--- a/src/schema/blogSchema.ts
+++ b/src/schema/blogSchema.ts
@@ -78,8 +78,8 @@ export const blogSchema = gql`
       title: String
       content: String
       tags: [String]
-      isHidden: Boolean
     ): Blog!
     deleteBlog(id: ID!): String!
+    hideBlog(id: ID!): Blog!
   }
 `;


### PR DESCRIPTION
**Summary**
This PR introduces the feature of hiding a blog by admin, to be only visible to admins and the author of it.

**Related Issues**
N/A

**Changes Made**

- created a resolver for hiding a blog
- modified getAllBlogs resolver to return the blogs only when they are not hidden.
- modified the schema to remove the isHidden field where it wasn't supposed to be. 


**how to test this? ** 

**locally**

- clone the repo and swith to ft/hiding-blog branch
- use any client for testing  
-use  `credentials:` email: admin@example.com password: password123 to login to the app
- try hiding and unhiding a blog to see the response using hideBlog mutation with the id as variable.

Screenshots
![Screenshot 2024-11-20 171933](https://github.com/user-attachments/assets/7a8c7b5d-d5ab-44ad-8453-c576d14617da)


Additional Notes
This PR also refactors some of the error handling logic for better readability.