### PR TITLE
#266 A user should be able to comment and react to a blog

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,8 @@ import { jobApplicationTypeDefs } from "./schema/jobApplicationSchema";
 import { jobApplicationResolver } from "./resolvers/jobApplicationResolver";
 import { blogRelatedResolvers } from "./resolvers/blogRelatedArticlesResolver";
 import { blogRelatedArticlesSchema } from "./schema/blogRelatedArticlesSchema";
+import { reactionSchema } from "./schema/reactionSchema";  
+import { reactionResolvers } from "./resolvers/reactionResolvers";
 import { DocSchema } from "./schema/doc";
 import { docResolver } from "./resolvers/Doc";
 const PORT = process.env.PORT || 3000;
@@ -137,7 +139,8 @@ const resolvers = mergeResolvers([
   commentLikeResolvers,
   commentReplyResolvers,
   blogRelatedResolvers,
-  docResolver
+  docResolver,
+  reactionResolvers
 ]);
 const typeDefs = mergeTypeDefs([
   applicationCycleTypeDefs,
@@ -180,7 +183,8 @@ const typeDefs = mergeTypeDefs([
   commentLikeSchema,
   jobApplicationTypeDefs,
   blogRelatedArticlesSchema,
-  DocSchema
+  DocSchema,
+  reactionSchema
 ]);
 
 const server = new ApolloServer({

--- a/src/models/blogModel.ts
+++ b/src/models/blogModel.ts
@@ -31,6 +31,24 @@ const blogSchema = new Schema({
       ref: "Comment",
     },
   ],
+  commentLikesCount: {
+    type: Number,
+    default: 0,
+  },
+  reactions: [
+    {
+      type: Schema.Types.ObjectId,
+      ref: "Reaction", 
+    },
+  ],
+  reactionsCount: {
+    LIKE: { type: Number, default: 0 },
+    LOVE: { type: Number, default: 0 },
+    CELEBRATE: { type: Number, default: 0 },
+    SUPPORT: { type: Number, default: 0 },
+    FUNNY: { type: Number, default: 0 },
+  },
+  
   isHidden: {
     type: Boolean,
     default: false,

--- a/src/models/commentModel.ts
+++ b/src/models/commentModel.ts
@@ -1,38 +1,16 @@
 import mongoose, { Schema, model } from "mongoose";
 
 const commentSchema = new Schema({
-  content: {
-    type: String,
-    required: true,
-  },
-  user: {
-    type: Schema.Types.ObjectId,
-    ref: "LoggedUserModel",
-    required: true,
-  },
-  blog: {
-    type: Schema.Types.ObjectId,
-    ref: "Blog",
-    required: true,
-  },
+  content: { type: String, required: true },
+  user: { type: Schema.Types.ObjectId, ref: "LoggedUserModel", required: true }, 
+  blog: { type: Schema.Types.ObjectId, ref: "Blog", required: true },
   likes: [
     {
       type: Schema.Types.ObjectId,
-      ref: "CommentLike",
-      required: true,
+      ref: "CommentLike", 
     },
   ],
-  replies: [
-    {
-      type: Schema.Types.ObjectId,
-      ref: "CommentReplies",
-      required: true,
-    },
-  ],
-  created_at: {
-    type: Date,
-    default: Date.now,
-  },
+  created_at: { type: Date, default: Date.now },
 });
 
 export const CommentModel = model("Comment", commentSchema);

--- a/src/models/reactionModel.ts
+++ b/src/models/reactionModel.ts
@@ -1,0 +1,33 @@
+import mongoose, { Schema, model } from "mongoose";
+
+export enum ReactionType {
+  LIKE = "LIKE",
+  CELEBRATE = "CELEBRATE",
+  SUPPORT = "SUPPORT",
+  LOVE = "LOVE",
+  FUNNY = "FUNNY",
+}
+
+const reactionSchema = new Schema({
+  user: {
+    type: Schema.Types.ObjectId,
+    ref: "LoggedUserModel",
+    required: true,
+  },
+  blog: {
+    type: Schema.Types.ObjectId,
+    ref: "Blog",
+    required: true,
+  },
+  type: {
+    type: String,
+    enum: Object.values(ReactionType), 
+    required: true,
+  },
+  created_at: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+export const ReactionModel = model("Reaction", reactionSchema);

--- a/src/resolvers/blogResolvers.ts
+++ b/src/resolvers/blogResolvers.ts
@@ -1,5 +1,4 @@
 import { BlogModel } from "../models/blogModel";
-import mongoose from "mongoose";
 
 import {
   GraphQLBoolean,
@@ -12,6 +11,7 @@ import { BlogType } from "../types/blogType";
 import { LoggedUserModel } from "../models/AuthUser";
 import { CustomGraphQLError } from "../utils/customErrorHandler";
 import { publishNotification } from "./adminNotificationsResolver";
+import { model } from "mongoose";
 
 interface CreateBlogArgs {
   title: string;
@@ -46,10 +46,6 @@ interface DeleteBlogArgs {
   id: string;
 }
 
-interface HideBlogArgs {
-  id: string;
-}
-
 export const blogResolvers = {
   Query: {
     getAllBlogs: {
@@ -57,37 +53,12 @@ export const blogResolvers = {
       args: {
         tag: { type: GraphQLString },
       },
-      resolve: async (_: any, { tag }: GetAllBlogsArgs, context: any) => {
-        try {
-          const userWithRole = context.currentUser
-            ? await LoggedUserModel.findById(context.currentUser._id).populate("role")
-            : null;
-
-          const filter = tag ? { tags: tag } : {};
-          const blogs = await BlogModel.find(filter).populate("author likes comments");
-
-          return blogs.filter((blog) => {
-            if (blog.isHidden) {
-              if (userWithRole) {
-                const authorId = blog.author._id;
-                const currentUserId = context.currentUser._id;
-
-                const isSameUser = new mongoose.Types.ObjectId(authorId).equals(new mongoose.Types.ObjectId(currentUserId));
-                const isAdmin = ["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName);
-
-                // Show hidden blog if the user is the author or has an admins role
-                return isSameUser || isAdmin;
-              }
-              return false;
-            }
-            return true;
-          });
-        } catch (error: any) {
-          throw new CustomGraphQLError(`Error fetching blogs: ${error.message}`);
-        }
+      resolve: async (_: any, { tag }: GetAllBlogsArgs) => {
+        const filter = tag ? { tags: tag } : {};
+        return await BlogModel.find(filter)
+        .populate("author likes comments reactions");
       },
     },
-
 
     getBlogsByAuthor: {
       type: new GraphQLList(BlogType),
@@ -96,7 +67,7 @@ export const blogResolvers = {
       },
       resolve: async (_: any, { authorId }: GetBlogsByAuthorArgs) => {
         return BlogModel.find({ author: authorId }).populate(
-          "author likes comments"
+          "author likes comments reactions"
         );
       },
     },
@@ -105,26 +76,26 @@ export const blogResolvers = {
       type: BlogType,
       args: { id: { type: new GraphQLNonNull(GraphQLID) } },
       resolve: async (_: any, { id }: GetBlogByIdArgs) => {
-        return BlogModel.findById(id)
-          .populate("author likes comments")
+        return await BlogModel.findById(id)
+        .populate("author likes comments reactions")
           .populate({
             path: "comments",
             populate: [
-              { path: "user", model: "LogedUserModel" },
+              { path: "user", model: "LoggedUserModel" },
               {
                 path: "likes",
                 model: "CommentLike",
                 populate: { path: "user", model: "LoggedUserModel" },
               },
-              {
-                path: "replies",
-                model: "CommentReply",
-                populate: { path: "user", model: "LoggedUserModel" },
-              },
+              // {
+              //   path: "replies",
+              //   model: "CommentReply",
+              //   populate: { path: "user", model: "LoggedUserModel" },
+              // },
             ],
           });
       },
-    },
+    },    
   },
 
   Mutation: {
@@ -186,28 +157,6 @@ export const blogResolvers = {
         await BlogModel.findByIdAndDelete(id);
         return "Blog deleted successfully";
       },
-    },
-
-    hideBlog: async (_: any, { id }: HideBlogArgs, context: any) => {
-
-      const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
-
-      if (!userWithRole ||
-        !["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
-        throw new CustomGraphQLError("You do not have permission to hide this blog.");
-      }
-      const blogId = new mongoose.Types.ObjectId(id);
-
-      const blog = await BlogModel.findById(blogId);
-      if (!blog) {
-        throw new CustomGraphQLError("Blog not found.");
-      }
-
-      blog.isHidden = !blog.isHidden;
-
-      await blog.save();
-
-      return blog;
     },
   },
 };

--- a/src/resolvers/blogResolvers.ts
+++ b/src/resolvers/blogResolvers.ts
@@ -1,4 +1,5 @@
 import { BlogModel } from "../models/blogModel";
+import mongoose from "mongoose";
 
 import {
   GraphQLBoolean,
@@ -11,7 +12,6 @@ import { BlogType } from "../types/blogType";
 import { LoggedUserModel } from "../models/AuthUser";
 import { CustomGraphQLError } from "../utils/customErrorHandler";
 import { publishNotification } from "./adminNotificationsResolver";
-import { model } from "mongoose";
 
 interface CreateBlogArgs {
   title: string;
@@ -46,6 +46,10 @@ interface DeleteBlogArgs {
   id: string;
 }
 
+interface HideBlogArgs {
+  id: string;
+}
+
 export const blogResolvers = {
   Query: {
     getAllBlogs: {
@@ -53,12 +57,37 @@ export const blogResolvers = {
       args: {
         tag: { type: GraphQLString },
       },
-      resolve: async (_: any, { tag }: GetAllBlogsArgs) => {
-        const filter = tag ? { tags: tag } : {};
-        return await BlogModel.find(filter)
-        .populate("author likes comments reactions");
+      resolve: async (_: any, { tag }: GetAllBlogsArgs, context: any) => {
+        try {
+          const userWithRole = context.currentUser
+            ? await LoggedUserModel.findById(context.currentUser._id).populate("role")
+            : null;
+
+          const filter = tag ? { tags: tag } : {};
+          const blogs = await BlogModel.find(filter).populate("author likes comments reactions");
+
+          return blogs.filter((blog) => {
+            if (blog.isHidden) {
+              if (userWithRole) {
+                const authorId = blog.author._id;
+                const currentUserId = context.currentUser._id;
+
+                const isSameUser = new mongoose.Types.ObjectId(authorId).equals(new mongoose.Types.ObjectId(currentUserId));
+                const isAdmin = ["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName);
+
+                // Show hidden blog if the user is the author or has an admins role
+                return isSameUser || isAdmin;
+              }
+              return false;
+            }
+            return true;
+          });
+        } catch (error: any) {
+          throw new CustomGraphQLError(`Error fetching blogs: ${error.message}`);
+        }
       },
     },
+
 
     getBlogsByAuthor: {
       type: new GraphQLList(BlogType),
@@ -157,6 +186,28 @@ export const blogResolvers = {
         await BlogModel.findByIdAndDelete(id);
         return "Blog deleted successfully";
       },
+    },
+
+    hideBlog: async (_: any, { id }: HideBlogArgs, context: any) => {
+
+      const userWithRole = await LoggedUserModel.findById(context.currentUser?._id).populate("role");
+
+      if (!userWithRole ||
+        !["admin", "superAdmin"].includes((userWithRole.role as any)?.roleName)) {
+        throw new CustomGraphQLError("You do not have permission to hide this blog.");
+      }
+      const blogId = new mongoose.Types.ObjectId(id);
+
+      const blog = await BlogModel.findById(blogId);
+      if (!blog) {
+        throw new CustomGraphQLError("Blog not found.");
+      }
+
+      blog.isHidden = !blog.isHidden;
+
+      await blog.save();
+
+      return blog;
     },
   },
 };

--- a/src/resolvers/commentLikeResolvers.ts
+++ b/src/resolvers/commentLikeResolvers.ts
@@ -1,41 +1,95 @@
-import { GraphQLID, GraphQLList, GraphQLNonNull } from "graphql";
-import { CommentLikeType } from "../types/commentLikeType";
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLObjectType,
+} from "graphql";
 import { CommentLikeModel } from "../models/commentLike";
 import { CommentModel } from "../models/commentModel";
+
+const CommentLikeDetailsType = new GraphQLObjectType({
+  name: "CommentLikeDetails",
+  fields: () => ({
+    count: { type: GraphQLInt }, 
+    likes: { type: new GraphQLList(GraphQLID) }, 
+  }),
+});
 
 export const commentLikeResolvers = {
   Query: {
     getCommentLikes: {
-      type: new GraphQLList(CommentLikeType),
-      args: { blog: { type: new GraphQLNonNull(GraphQLID) } },
+      type: new GraphQLObjectType({
+        name: "CommentLikes",
+        fields: {
+          count: { type: GraphQLInt },
+        },
+      }),
+      args: { comment: { type: new GraphQLNonNull(GraphQLID) } },
       resolve: async (_: any, { comment }: any) => {
-        return await CommentLikeModel.find({ comment })
-          .populate("user")
-          .populate({
-            path: "comment",
-            populate: { path: "user" },
-          });
+        try {
+          const commentData = await CommentModel.findById(comment).select("likes");
+
+          if (!commentData) {
+            throw new Error("Comment not found.");
+          }
+
+          return { count: commentData.likes.length };
+        } catch (error) {
+          console.error("Error fetching comment likes:", error);
+          throw new Error("Failed to fetch comment likes.");
+        }
       },
     },
   },
   Mutation: {
     addCommentLike: {
-      type: CommentLikeType,
+      type: GraphQLInt,
       args: {
         user: { type: new GraphQLNonNull(GraphQLID) },
         comment: { type: new GraphQLNonNull(GraphQLID) },
       },
       resolve: async (_: any, { user, comment }: any) => {
-        const like = new CommentLikeModel({ user, comment });
-        await CommentModel.findByIdAndUpdate(comment, {
-          $push: { likes: like._id },
-        });
-        const savedLike = await like.save();
-        return (await savedLike.populate("user")).populate({
-          path: "comment",
-          populate: { path: "user" },
-        });
+        try {
+          const existingLike = await CommentLikeModel.findOne({ user, comment });
+  
+          if (existingLike) {
+            await CommentLikeModel.findByIdAndDelete(existingLike._id);
+  
+            const updatedComment = await CommentModel.findByIdAndUpdate(
+              comment,
+              { $pull: { likes: existingLike._id } },
+              { new: true }
+            );
+  
+            if (!updatedComment) {
+              throw new Error("Failed to update comment after removing the like.");
+            }
+  
+            const updatedLikeCount = updatedComment.likes.length;
+            return updatedLikeCount;
+          }
+  
+          const like = new CommentLikeModel({ user, comment });
+  
+          const savedLike = await like.save();
+          const updatedComment = await CommentModel.findByIdAndUpdate(
+            comment,
+            { $push: { likes: savedLike._id } },
+            { new: true }
+          );
+  
+          if (!updatedComment) {
+            throw new Error("Failed to update comment with the new like.");
+          }
+  
+          const updatedLikeCount = updatedComment.likes.length;
+          return updatedLikeCount;
+        } catch (error) {
+          console.error("Error updating comment like:", error);
+          throw new Error("Failed to update comment like.");
+        }
       },
     },
-  },
+  },  
 };

--- a/src/resolvers/commentReplyResolvers.ts
+++ b/src/resolvers/commentReplyResolvers.ts
@@ -17,7 +17,7 @@ export const commentReplyResolvers = {
   Query: {
     getRepliesByComment: {
       type: new GraphQLList(CommentReplyType),
-      args: { blog: { type: new GraphQLNonNull(GraphQLID) } },
+      args: { comment: { type: new GraphQLNonNull(GraphQLID) } },
       resolve: async (_: any, { comment }: GetRepliesByCommentArgs) => {
         return await CommentReplyModel.find({ comment })
           .populate("user")
@@ -40,7 +40,7 @@ export const commentReplyResolvers = {
         _: any,
         { content, user, comment }: AddCommentReplyArgs
       ) => {
-        const commentReply = new CommentModel({ content, user, comment });
+        const commentReply = new CommentReplyModel({ content, user, comment });
         await CommentModel.findByIdAndUpdate(comment, {
           $push: { comments: commentReply._id },
         });

--- a/src/resolvers/commentResolvers.ts
+++ b/src/resolvers/commentResolvers.ts
@@ -2,11 +2,22 @@ import { GraphQLID, GraphQLList, GraphQLNonNull, GraphQLString } from "graphql";
 import { CommentModel } from "../models/commentModel";
 import { BlogModel } from "../models/blogModel";
 import { CommentType } from "../types/commentType";
+import { GraphQLInt } from "graphql";
+import { CommentLikeModel } from "../models/commentLike";
 
 interface AddCommentArgs {
   content: string;
   user: string;
   blog: string;
+}
+
+interface UpdateCommentArgs {
+  id: string;
+  content: string;
+}
+
+interface DeleteCommentArgs {
+  id: string;
 }
 
 interface GetCommentsByBlogArgs {
@@ -18,13 +29,38 @@ export const commentResolvers = {
     getCommentsByBlog: {
       type: new GraphQLList(CommentType),
       args: { blog: { type: new GraphQLNonNull(GraphQLID) } },
-      resolve: async (_: any, { blog }: GetCommentsByBlogArgs) => {
-        return await CommentModel.find({ blog })
-          .populate("user")
-          .populate({
-            path: "blog",
-            populate: { path: "author" },
-          });
+      resolve: async (_: any, { blog }: { blog: string }) => {
+        try {
+          const blogData = await BlogModel.findById(blog);
+          if (!blogData) {
+            throw new Error("Blog not found");
+          }
+  
+          const comments = await CommentModel.find({ blog })
+            .populate({
+              path: "user",
+              select: "_id firstname lastname email", 
+            })
+            .lean(); 
+  
+          const commentsWithLikes = await Promise.all(
+            comments.map((comment) => ({
+              ...comment,
+              id: comment._id.toString(), 
+              user: comment.user
+                ? {
+                    ...comment.user,
+                    id: comment.user._id.toString(), 
+                  }
+                : null, 
+            }))
+          );
+  
+          return commentsWithLikes;
+        } catch (error) {
+          console.error("Error fetching comments by blog:", error);
+          throw new Error("Failed to fetch comments by blog.");
+        }
       },
     },
   },
@@ -46,6 +82,49 @@ export const commentResolvers = {
           path: "blog",
           populate: { path: "author" },
         });
+      },
+    },
+    updateComment: {
+      type: CommentType,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+        content: { type: new GraphQLNonNull(GraphQLString) },
+      },
+      resolve: async (_: any, { id, content }: UpdateCommentArgs) => {
+        const updatedComment = await CommentModel.findByIdAndUpdate(
+          id,
+          { content },
+          { new: true }
+        )
+          .populate("user")
+          .populate({
+            path: "blog",
+            populate: { path: "author" },
+          });
+
+        if (!updatedComment) {
+          throw new Error("Comment not found");
+        }
+        return updatedComment;
+      },
+    },
+    deleteComment: {
+      type: GraphQLString,
+      args: {
+        id: { type: new GraphQLNonNull(GraphQLID) },
+      },
+      resolve: async (_: any, { id }: DeleteCommentArgs) => {
+        const deletedComment = await CommentModel.findByIdAndDelete(id);
+
+        if (!deletedComment) {
+          throw new Error("Comment not found");
+        }
+
+        await BlogModel.findByIdAndUpdate(deletedComment.blog, {
+          $pull: { comments: id },
+        });
+
+        return "Comment deleted successfully";
       },
     },
   },

--- a/src/resolvers/reactionResolvers.ts
+++ b/src/resolvers/reactionResolvers.ts
@@ -1,0 +1,72 @@
+import { GraphQLInputObjectType, GraphQLID, GraphQLNonNull, GraphQLEnumType, GraphQLString, GraphQLInt, GraphQLBoolean } from "graphql";
+import { ReactionModel } from "../models/reactionModel";
+import { ReactionType as ReactionGraphQLType } from "../types/reactionType";
+import { ReactionType } from "../models/reactionModel";  
+import { BlogModel } from "../models/blogModel";
+import mongoose from 'mongoose';
+
+
+const addReaction = async (_: any, { reactionFields }: { reactionFields: any }) => {
+  const reaction = new ReactionModel(reactionFields);
+  await reaction.save();
+
+  const blog = await BlogModel.findById(reactionFields.blog);
+  if (blog) {
+    await BlogModel.findByIdAndUpdate(
+      reactionFields.blog,
+      {
+        $push: { reactions: reaction._id },
+        $inc: { [`reactionsCount.${reactionFields.type}`]: 1 }, 
+      },
+      { new: true }
+    );
+  }
+
+  const populatedReaction = await ReactionModel.findById(reaction._id)
+    .populate("blog user");
+
+  return populatedReaction;
+};
+
+
+
+const removeReaction = async (_: any, { user, blog }: { user: string, blog: string }) => {
+  const reaction = await ReactionModel.findOneAndDelete({ user, blog });
+
+  if (reaction) {
+    await BlogModel.findByIdAndUpdate(blog, {
+      $inc: { [`reactionsCount.${reaction.type}`]: -1 },
+    });
+  }
+
+  return reaction != null; 
+};
+
+const getReactionsByBlog = async (_: any, { blog }: { blog: string }) => {
+  return await ReactionModel.find({ blog }).populate("blog user")
+};
+
+const getAllReactionsCount = async (_: any, { blog }: { blog: string }) => {
+  const reactionCount = await ReactionModel.countDocuments({ blog: new mongoose.Types.ObjectId(blog) });
+  return reactionCount;
+};
+
+const getReactionsCountByBlogAndType = async (_: any, { blog, type }: { blog: string, type: string }) => {
+  const reactionCount = await ReactionModel.countDocuments({
+    blog: new mongoose.Types.ObjectId(blog),
+    type: type.toUpperCase() 
+  });
+  return reactionCount;
+};
+
+export const reactionResolvers = {
+  Mutation: {
+    addReaction,
+    removeReaction,
+  },
+  Query: {
+    getReactionsByBlog,
+    getAllReactionsCount,
+    getReactionsCountByBlogAndType,
+  },
+};

--- a/src/schema/blogSchema.ts
+++ b/src/schema/blogSchema.ts
@@ -41,6 +41,15 @@ export const blogSchema = gql`
     createdAt: String
   }
 
+  type Reaction {
+    id: ID
+    user: LoggedUserModel
+    blog: Blog
+    type: ReactionType
+    created_at: String
+  }
+
+
   type Blog {
     id: ID!
     title: String!
@@ -48,7 +57,8 @@ export const blogSchema = gql`
     coverImage: String!
     images: [String]
     likes: [Like]!
-    comments: [Comment]!
+    comments: [Comment]
+    reactions: [Reaction]
     isHidden: Boolean
     author: LoggedUserModel!
     tags: [String]
@@ -78,8 +88,8 @@ export const blogSchema = gql`
       title: String
       content: String
       tags: [String]
+      isHidden: Boolean
     ): Blog!
     deleteBlog(id: ID!): String!
-    hideBlog(id: ID!): Blog!
   }
 `;

--- a/src/schema/blogSchema.ts
+++ b/src/schema/blogSchema.ts
@@ -88,8 +88,10 @@ export const blogSchema = gql`
       title: String
       content: String
       tags: [String]
-      isHidden: Boolean
     ): Blog!
     deleteBlog(id: ID!): String!
+    hideBlog(id: ID!): Blog!
   }
-`;
+`
+
+  

--- a/src/schema/commentLikeSchema.ts
+++ b/src/schema/commentLikeSchema.ts
@@ -48,8 +48,13 @@ export const commentLikeSchema = gql`
   }
 
   type Query {
-    getCommentLikes(comment: ID!): [CommentLike!]!
-  }
+  getCommentLikes(comment: ID!): CommentLikeDetails!
+}
+
+type CommentLikeDetails {
+  count: Int!
+  likes: [CommentLike!]!
+}
 
   input CommentLikeInput {
     user: ID!

--- a/src/schema/commentSchema.ts
+++ b/src/schema/commentSchema.ts
@@ -14,6 +14,8 @@ export const commentSchema = gql`
     resetToken: String
     resetTokenExpiration: String
     cohort: ID
+    commentCount: Int
+    likesCount: Int 
   }
 
   type Like {
@@ -61,10 +63,12 @@ export const commentSchema = gql`
     likes: [CommentLike]
     replies: [CommentReply]
     createdAt: String
+    commentCount: Int
   }
 
   type Query {
     getCommentsByBlog(blog: ID!): [Comment!]!
+    countCommentsByBlog(blog: ID!): Int!
   }
 
   input CommentInput {
@@ -75,5 +79,7 @@ export const commentSchema = gql`
 
   type Mutation {
     addComment(commentFields: CommentInput): Comment!
+    updateComment(id: ID!, content: String!): Comment!
+    deleteComment(id: ID!): String!
   }
 `;

--- a/src/schema/reactionSchema.ts
+++ b/src/schema/reactionSchema.ts
@@ -1,0 +1,41 @@
+import { gql } from "apollo-server-core";
+
+export const reactionSchema = gql`
+  enum ReactionType {
+    LIKE
+    CELEBRATE
+    SUPPORT
+    LOVE
+    FUNNY
+  }
+
+  type Reaction {
+    id: ID
+    user: LoggedUserModel
+    blog: Blog
+    type: ReactionType
+    created_at: String
+  }
+
+  type ReactionCount {
+    type: ReactionType
+    count: Int
+  }
+
+  type Query {
+    getReactionsByBlog(blog: ID!): [Reaction!]!
+    getAllReactionsCount(blog: ID!): Int
+    getReactionsCountByBlogAndType(blog: ID!, type: ReactionType!): Int
+  }
+
+  input ReactionInput {
+    user: ID!
+    blog: ID!
+    type: ReactionType!
+  }
+
+  type Mutation {
+    addReaction(reactionFields: ReactionInput): Reaction!
+    removeReaction(user: ID!, blog: ID!): Boolean!
+  }
+`;

--- a/src/types/reactionType.ts
+++ b/src/types/reactionType.ts
@@ -1,0 +1,25 @@
+import { GraphQLObjectType, GraphQLID, GraphQLString, GraphQLEnumType } from "graphql";
+import { UserType } from "./userType";
+import { BlogType } from "./blogType";
+
+export const ReactionEnumType = new GraphQLEnumType({
+  name: "ReactionType",
+  values: {
+    LIKE: { value: "LIKE" },
+    CELEBRATE: { value: "CELEBRATE" },
+    SUPPORT: { value: "SUPPORT" },
+    LOVE: { value: "LOVE" },
+    FUNNY: { value: "FUNNY" },
+  },
+});
+
+export const ReactionType = new GraphQLObjectType({
+  name: "Reaction",
+  fields: () => ({
+    id: { type: GraphQLID },
+    user: { type: UserType }, 
+    blog: { type: BlogType }, 
+    type: { type: ReactionEnumType }, 
+    created_at: { type: GraphQLString }, 
+  }),
+});


### PR DESCRIPTION
### PR Description
A user should be able to comment and react to blog posts.

### Description of tasks that were expected to be completed
This PR introduces functionality allowing users to:
- Add comments to a blog post.
- Fetch all comments related to a given blog post.
- React to blog posts with reactions (e.g., Like, Love, Support, Funny).
- Like individual comments.
- Add replies to specific comments.

### Related Issues
https://github.com/atlp-rwanda/atlp-devpulse-fn/issues/266

### Changes Made:
- Added a model to handle reactions at the database level.
- Created a schema to define the GraphQL schema for comments.
- Created src/schema/reactionSchema.ts to define the GraphQL schema for reactions.
- Added a resolver for creating comments.
- Added a resolver for managing likes on comments.
- Added a resolver for for managing reactions on both blog posts.

### How to test this PR
- Clone the repository
- Run npm install to install dependencies and navigate to the `ft-comments-reactions-bn` branch
- Start the development server using npm run dev.
- Perform any reaction or comment query or mutation and verify the changes reflect in the database.

### Screenshoots
<img width="949" alt="image" src="https://github.com/user-attachments/assets/cd3dd5bb-d1f2-469d-9cd6-11ef0a0fb752">
<img width="634" alt="image" src="https://github.com/user-attachments/assets/0b55fb38-13da-4432-bce9-9c6dec79ad65">
<img width="629" alt="image" src="https://github.com/user-attachments/assets/2849d4ff-d087-46c8-908a-34924b10c381">
<img width="630" alt="image" src="https://github.com/user-attachments/assets/dc5f9c1d-5a6a-4d2b-9a1d-ac9e1e429eb3">


